### PR TITLE
Adjust splitter regex to allow parentheses

### DIFF
--- a/src/defines.h
+++ b/src/defines.h
@@ -143,6 +143,6 @@ typedef struct {
     uint32_t word = 0;
 } Instruction;
 
-const static auto splitter = QRegularExpression(R"((\t|\(|\)))");
+const static auto splitter = QRegularExpression(R"(\t|\((?=x(?:[1-2]\d|3[0-1]|\d)|t[0-6]|a[0-7]|s(?:1[0-1]|\d)|[sgt]p|zero)|(?:x(?:[1-2]\d|3[0-1]|\d)|t[0-6]|a[0-7]|s(?:1[0-1]|\d)|[sgt]p|zero)\K\))");
 
 #endif  // DEFINES_H

--- a/src/defines.h
+++ b/src/defines.h
@@ -143,6 +143,7 @@ typedef struct {
     uint32_t word = 0;
 } Instruction;
 
+// splits only at tab characters and parentheses when they include a register name
 const static auto splitter = QRegularExpression(R"(\t|\((?=x(?:[1-2]\d|3[0-1]|\d)|t[0-6]|a[0-7]|s(?:1[0-1]|\d)|[sgt]p|zero)|(?:x(?:[1-2]\d|3[0-1]|\d)|t[0-6]|a[0-7]|s(?:1[0-1]|\d)|[sgt]p|zero)\K\))");
 
 #endif  // DEFINES_H

--- a/src/lexerutilities.h
+++ b/src/lexerutilities.h
@@ -4,14 +4,16 @@
 #include <QStringList>
 
 static QStringList splitQuotes(const QStringList& list) {
-    // Manual string splitter - splits at ' ' (space) and ',' (comma) characters, unless test is delimitered by quotes
+    // Manual string splitter - splits at ' ' (space) and ',' (comma) characters, unless test is delimitered by quotes or parentheses
     QStringList ret;
     for (const auto& s : list) {
         QString outString;
         bool inQuote = false;
+        bool inParen = false;
         for (int i = 0; i < s.length(); i++) {
             inQuote ^= s[i] == '"';
-            if ((s[i] == ' ' || s[i] == ',') && !inQuote) {
+            inParen = (inParen || (s[i] == '(')) && s[i] != ')';
+            if ((s[i] == ' ' || s[i] == ',') && !inQuote && !inParen) {
                 ret.append(outString);
                 outString.clear();
             } else {


### PR DESCRIPTION
This regex is a bit of a kludge and has several non-capturing groups as well as some lookaheads. It also wouldn't accept the floating point registers (but my understanding is that support for RV32F/RV32D is not available yet).

If a type has the same name as a register, then this will break. I am unsure of how that can be avoided without more complex changes than to just the regex. Hopefully in Compiler Explorer examples, that wouldn't be an issue.

Resolves #10