### PR TITLE
Typo in printing value.

### DIFF
--- a/examples/assembly/Conditional branching
+++ b/examples/assembly/Conditional branching
@@ -21,5 +21,5 @@ e:
 	li a1,2
 f:
 	mv	a2,a0
-	li	a0,10
+	li	a0,1
 	ecall


### PR DESCRIPTION
I am assuming that it should print the value of a1 but someone made a typo while creating this example.