### PR TITLE
Make print_string support UTF-8

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -53,14 +53,14 @@ void Parser::parseFile() {
 QString Parser::getStringAt(uint32_t address) const {
     // Returns the null-terminated string starting at @address
     MainMemory* memPtr = Pipeline::getPipeline()->getRuntimeMemoryPtr();
-    QString string;
+    QByteArray string;
     char read;
     do {
         read = memPtr->read(address) & 0xff;
         string.append(read);
         address++;
     } while (read != '\0');
-    return string;
+    return QString::fromUtf8(string);
 }
 
 void Parser::clear() {


### PR DESCRIPTION
thethirdone/rars#28 brought unicode to my attention and I tested Ripes to see if it could handle unicode text. 

I found Ripes can input from `.asciz` just fine as UTF-8, but couldn't print those strings.

A quick test program:
```
.data
label:
    .asciz "█"
.text
    li a0, 4
    la a1, label
    ecall
```

Current output:
![output-current](https://user-images.githubusercontent.com/2322200/58130450-de082300-7bd0-11e9-93cf-bf5ff47b63c5.png)

With this PR:
![output-pr](https://user-images.githubusercontent.com/2322200/58130449-dd6f8c80-7bd0-11e9-9683-a30114765a91.png)
