### PR TITLE
Wrong type conversion in the generation of hazard control signals

### DIFF
--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -1,4 +1,4 @@
-#include "pipeline.h"
+﻿#include "pipeline.h"
 
 #include "parser.h"
 
@@ -596,7 +596,7 @@ void Pipeline::hazardControlGen() {
     bool branchHazard = branchEcallHazardFromMem || branchEcallHazardFromEx;
 
     // Load Use hazard: Loaded variable is needed in execute stage
-    bool loadUseHazard = (r1 == (uint32_t)r_writeReg_IDEX || r2 == (uint32_t)r_writeReg_IDEX) && (bool)r_MemRead_IDEX;
+    bool loadUseHazard = (r1 == (uint32_t)r_writeReg_IDEX || r2 == (uint32_t)r_writeReg_IDEX) && (int)r_MemRead_IDEX;
 
     if (branchHazard || loadUseHazard) {
         // Stall until hazard is resolved - keep IFID and PC vaues, and reset IDEX registers


### PR DESCRIPTION
The signal `loadUseHazard` is wrongly calculated in `hazardControlGen` function in pipeline. 

The conversion of `r_MemRead_IDEX` to `bool` will only look at the last bit of `s_MemRead`, which may be assigned to enum `MemRead` that can be greater than 1.

There is a simple program that can trigger this bug:

```asm
li a0, 1000
li a1, 2000
sb a0, 0(a1)
lbu a0, 0(a1)
addi a2, a0, 0
```

The correct value of `a2` should be `1000`, but Ripes actually gives `2000`. Using `LBU` and `LH` willl cause this problem, while `LB`, `LW` and `LHU` won't, which corresponds to their actual values in the enum `MemRead`.