### PR TITLE
Replace `jalr x0 x1 0` with psuedo-op `jr x1` in examples

### DIFF
--- a/examples/assembly/Complex multiplication
+++ b/examples/assembly/Complex multiplication
@@ -40,42 +40,42 @@ myMult:
     li t0, 32   # Iteration variable
     li t3, 0    # initialize temporary product register to 0
 
-  start: 
+  start:
     mv   t1, a1     # move multiplier to temporary register
     andi t1, t1, 1  # mask first bit
     beq  t1, x0, shift
     add  t3, t3, a0
 
-  shift: 
+  shift:
     slli a0, a0, 1
     srai a1, a1, 1  # make an arithmetic right shift for signed multiplication
     addi t0, t0, -1 # decrement loop index
     bnez t0, start  # branch if loop index is not 0
     mv   a0, t3     # move final product to result register
-    jalr x0, x1 0
+    jr x1
 
 complexMul:
 	# Place the 4 input arguments and return address on the stack
 	addi sp, sp, -28
     sw x0, 24(sp) # tmp. res 2
-    sw x0, 20(sp) # tmp. res 1 
+    sw x0, 20(sp) # tmp. res 1
     sw ra, 16(sp) # return address
     sw a0, 12(sp) # a
     sw a1, 8(sp)  # b
     sw a2, 4(sp)  # c
     sw a3, 0(sp)  # d
-    
+
     # (a + ib)(c + id) = (ac − bd) + i(ad + bc)
     # Step 1: a*c
     mv a1, a2   # Move C from a2 to a1
     jal myMult
     sw a0, 20(sp)   # push onto tmp. res 1
-    
+
     # step 2: b*d
     lw  a0, 8(sp)
     lw  a1, 0(sp)
     jal myMult
-    
+
     # step 3: (ac − bd)
     lw  t0, 20(sp) # Reload a*c from stack
     sub t2 t0 a0 # t2 contains real part of multiplication
@@ -101,6 +101,6 @@ complexMul:
 
     lw   ra, 16(sp) # Reload return address from stack
     addi sp, sp, 28 # Restore stack pointer
-    jalr x0, x1, 0
+    jr x1
 
 end:nop

--- a/examples/assembly/Console printing
+++ b/examples/assembly/Console printing
@@ -46,7 +46,7 @@ printNewline:
     la a0, newline
     li a7, 4
     ecall
-    jalr x0, x1, 0
+    jr x1
 
 # --- LoopPrint ---
 # Loops in the range [a0;a1] and prints the loop invariant to console
@@ -68,7 +68,7 @@ loop:
     # Increment
     addi t0, t0, 1
     ble  t0, t1, loop
-    jalr x0, x1, 0
+    jr x1
 
 exit:
     li a7, 10

--- a/examples/assembly/Factorial function
+++ b/examples/assembly/Factorial function
@@ -29,7 +29,7 @@ fact:
 
         addi a0, zero, 1
         addi sp, sp, 16
-        jalr x0, x1, 0
+        jr x1
 
 nfact:
         addi a0, a0, -1


### PR DESCRIPTION
My editor automatically removed some white-space. If you want I can strip those changes out.

If you'd rather keep the non-pseudo instructions just let me know. Just wanted to add a convenient trick I learned today :)

Thanks for the great app!