### PR TITLE
[Assembler] Hint for assembler editor

### DIFF
--- a/src/assembler/instruction.h
+++ b/src/assembler/instruction.h
@@ -103,14 +103,15 @@ struct Opcode : public Field {
 };
 
 struct Reg : public Field {
+    enum class Regsd { rd, rs1, rs2 };
     /**
      * @brief Reg
      * @param tokenIndex: Index within a list of decoded instruction tokens that corresponds to the register index
      * @param range: range in instruction field containing register index value
      */
-    Reg(const ISAInfoBase* isa, unsigned tokenIndex, BitRange range) : Field(tokenIndex), m_range(range), m_isa(isa) {}
-    Reg(const ISAInfoBase* isa, unsigned tokenIndex, unsigned _start, unsigned _stop)
-        : Field(tokenIndex), m_range({_start, _stop}), m_isa(isa) {}
+    Reg(const ISAInfoBase* isa, unsigned tokenIndex, BitRange range, Regsd _regsd) : Field(tokenIndex), m_range(range), m_isa(isa), regsd(_regsd) {}
+    Reg(const ISAInfoBase* isa, unsigned tokenIndex, unsigned _start, unsigned _stop, Regsd _regsd)
+        : Field(tokenIndex), m_range({_start, _stop}), m_isa(isa), regsd(_regsd) {}
     std::optional<Assembler::Error> apply(const Assembler::TokenizedSrcLine& line, uint32_t& instruction,
                                           FieldLinkRequest&) const override {
         bool success;
@@ -135,6 +136,7 @@ struct Reg : public Field {
 
     const BitRange m_range;
     const ISAInfoBase* m_isa;
+    const Regsd regsd;
 };
 
 struct ImmPart {
@@ -289,14 +291,51 @@ public:
     }
 
     AssembleRes assemble(const Assembler::TokenizedSrcLine& line) const {
+        QString Hint = "";
+        // if(dynamic_cast<Imm*>(m_fields[1].get()))
+        //     std::cout << "Its Imm" << std::endl;
+        // else if(dynamic_cast<Reg*>(m_fields[1].get()))
+        //     std::cout << "Its Reg" << std::endl;
+        // else
+        //     std::cout << "Nothing" << std::endl;
+
+        for(int i = 0; i < (m_expectedTokens-1); i++){
+            //Imm
+            if(dynamic_cast<Imm*>(m_fields[i].get()))
+                Hint = Hint + " [Imm]";
+            //Reg
+            else
+            {
+                Reg* regField = dynamic_cast<Reg*>(m_fields[i].get());
+                
+                if(regField->regsd == Reg::Regsd::rs1)
+                    Hint = Hint + " [rs1]";
+                else if(regField->regsd == Reg::Regsd::rs2)
+                    Hint = Hint + " [rs2]";
+                else
+                    Hint = Hint + " [rd]";
+            }    
+        }
+
+        // Reg* regField = dynamic_cast<Reg*>(m_fields[0].get());
+        // if(regField->regsd == Reg::Regsd::rs1)
+        //     std::cout << "rs1" << std::endl;
+        // else if(regField->regsd == Reg::Regsd::rs2)
+        //     std::cout << "rs2" << std::endl;
+        // else
+        //     std::cout << "rd" << std::endl;
+
         if (line.tokens.length() != m_expectedTokens) {
-            return Assembler::Error(line.sourceLine, "Instruction '" + m_opcode.name + "' expects " +
+            return Assembler::Error(line.sourceLine, "Instruction " + m_opcode.name + Hint + " expects " +
                                                          QString::number(m_expectedTokens - 1) +
                                                          " arguments, but got " +
                                                          QString::number(line.tokens.length() - 1));
         }
         return m_assembler(this, line);
     }
+
+
+
     DisassembleRes disassemble(const uint32_t instruction, const uint32_t address,
                                const ReverseSymbolMap& symbolMap) const {
         return m_disassembler(this, instruction, address, symbolMap);

--- a/src/assembler/pseudoinstruction.h
+++ b/src/assembler/pseudoinstruction.h
@@ -30,7 +30,7 @@ public:
      * Does not relate to actual regs/imms in an instruction word, but solely used for a pseudoinstruction to
      * be used within the instruction token checking system.
      */
-    static std::shared_ptr<Reg> reg() { return std::make_shared<Reg>(nullptr, 0, 0, 0, Reg::Regsd::rd); }
+    static std::shared_ptr<Reg> reg() { return std::make_shared<Reg>(nullptr, 0, 0, 0, "rd"); }
     static std::shared_ptr<Imm> imm() { return std::make_shared<Imm>(0, 0, Imm::Repr::Hex, std::vector<ImmPart>{}); }
 
 private:

--- a/src/assembler/pseudoinstruction.h
+++ b/src/assembler/pseudoinstruction.h
@@ -30,7 +30,7 @@ public:
      * Does not relate to actual regs/imms in an instruction word, but solely used for a pseudoinstruction to
      * be used within the instruction token checking system.
      */
-    static std::shared_ptr<Reg> reg() { return std::make_shared<Reg>(nullptr, 0, 0, 0); }
+    static std::shared_ptr<Reg> reg() { return std::make_shared<Reg>(nullptr, 0, 0, 0, Reg::Regsd::rd); }
     static std::shared_ptr<Imm> imm() { return std::make_shared<Imm>(0, 0, Imm::Repr::Hex, std::vector<ImmPart>{}); }
 
 private:

--- a/src/assembler/rv32i_assembler.cpp
+++ b/src/assembler/rv32i_assembler.cpp
@@ -41,7 +41,7 @@ RV32I_Assembler::initInstructions(const ISAInfo<ISA::RV32I>* isa) const {
 #define BType(name, funct3)                                                                              \
     std::shared_ptr<Instruction>(new Instruction(                                                        \
         Opcode(name, {OpPart(0b1100011, 0, 6), OpPart(funct3, 12, 14)}),                                 \
-        {std::make_shared<Reg>(isa, 1, 15, 19, Reg::Regsd::rs1), std::make_shared<Reg>(isa, 2, 20, 24, Reg::Regsd::rs2),                   \
+        {std::make_shared<Reg>(isa, 1, 15, 19, "rs1"), std::make_shared<Reg>(isa, 2, 20, 24, "rs2"),                   \
          std::make_shared<Imm>(                                                                          \
              3, 13, Imm::Repr::Signed,                                                                   \
              std::vector{ImmPart(12, 31, 31), ImmPart(11, 7, 7), ImmPart(5, 25, 30), ImmPart(1, 8, 11)}, \
@@ -50,44 +50,44 @@ RV32I_Assembler::initInstructions(const ISAInfo<ISA::RV32I>* isa) const {
 #define IType(name, funct3)                                                                           \
     std::shared_ptr<Instruction>(                                                                     \
         new Instruction(Opcode(name, {OpPart(0b0010011, 0, 6), OpPart(funct3, 12, 14)}),              \
-                        {std::make_shared<Reg>(isa, 1, 7, 11, Reg::Regsd::rd), std::make_shared<Reg>(isa, 2, 15, 19, Reg::Regsd::rs1), \
+                        {std::make_shared<Reg>(isa, 1, 7, 11, "rd"), std::make_shared<Reg>(isa, 2, 15, 19, "rs1"), \
                          std::make_shared<Imm>(3, 12, Imm::Repr::Signed, std::vector{ImmPart(0, 20, 31)})}))
 
 #define LoadType(name, funct3)                                                                        \
     std::shared_ptr<Instruction>(                                                                     \
         new Instruction(Opcode(name, {OpPart(0b0000011, 0, 6), OpPart(funct3, 12, 14)}),              \
-                        {std::make_shared<Reg>(isa, 1, 7, 11, Reg::Regsd::rd), std::make_shared<Reg>(isa, 3, 15, 19, Reg::Regsd::rs1), \
+                        {std::make_shared<Reg>(isa, 1, 7, 11, "rd"), std::make_shared<Reg>(isa, 3, 15, 19, "rs1"), \
                          std::make_shared<Imm>(2, 12, Imm::Repr::Signed, std::vector{ImmPart(0, 20, 31)})}))
 
 #define IShiftType(name, funct3, funct7)                                                                         \
     std::shared_ptr<Instruction>(                                                                                \
         new Instruction(Opcode(name, {OpPart(0b0010011, 0, 6), OpPart(funct3, 12, 14), OpPart(funct7, 25, 31)}), \
-                        {std::make_shared<Reg>(isa, 1, 7, 11, Reg::Regsd::rd), std::make_shared<Reg>(isa, 2, 15, 19, Reg::Regsd::rs1),            \
+                        {std::make_shared<Reg>(isa, 1, 7, 11, "rd"), std::make_shared<Reg>(isa, 2, 15, 19, "rs1"),            \
                          std::make_shared<Imm>(3, 5, Imm::Repr::Unsigned, std::vector{ImmPart(0, 20, 24)})}))
 
 #define RType(name, funct3, funct7)                                                                              \
     std::shared_ptr<Instruction>(                                                                                \
         new Instruction(Opcode(name, {OpPart(0b0110011, 0, 6), OpPart(funct3, 12, 14), OpPart(funct7, 25, 31)}), \
-                        {std::make_shared<Reg>(isa, 1, 7, 11, Reg::Regsd::rd), std::make_shared<Reg>(isa, 2, 15, 19, Reg::Regsd::rs1),            \
-                         std::make_shared<Reg>(isa, 3, 20, 24, Reg::Regsd::rs2)}))
+                        {std::make_shared<Reg>(isa, 1, 7, 11, "rd"), std::make_shared<Reg>(isa, 2, 15, 19, "rs1"),            \
+                         std::make_shared<Reg>(isa, 3, 20, 24, "rs2")}))
 
 #define SType(name, funct3)                                                                                   \
     std::shared_ptr<Instruction>(new Instruction(                                                             \
         Opcode(name, {OpPart(0b0100011, 0, 6), OpPart(funct3, 12, 14)}),                                      \
-        {std::make_shared<Reg>(isa, 3, 15, 19, Reg::Regsd::rs1),                                                               \
+        {std::make_shared<Reg>(isa, 3, 15, 19, "rs1"),                                                               \
          std::make_shared<Imm>(2, 12, Imm::Repr::Signed, std::vector{ImmPart(5, 25, 31), ImmPart(0, 7, 11)}), \
-         std::make_shared<Reg>(isa, 1, 20, 24, Reg::Regsd::rs2)}))
+         std::make_shared<Reg>(isa, 1, 20, 24, "rs2")}))
 
 #define UType(name, opcode)                                    \
     std::shared_ptr<Instruction>(                              \
         new Instruction(Opcode(name, {OpPart(opcode, 0, 6)}),  \
-                        {std::make_shared<Reg>(isa, 1, 7, 11, Reg::Regsd::rd), \
+                        {std::make_shared<Reg>(isa, 1, 7, 11, "rd"), \
                          std::make_shared<Imm>(2, 32, Imm::Repr::Hex, std::vector{ImmPart(0, 12, 31)})}))
 
 #define JType(name, opcode)                                                                                  \
     std::shared_ptr<Instruction>(new Instruction(                                                            \
         Opcode(name, {OpPart(opcode, 0, 6)}),                                                                \
-        {std::make_shared<Reg>(isa, 1, 7, 11, Reg::Regsd::rd),                                                               \
+        {std::make_shared<Reg>(isa, 1, 7, 11, "rd"),                                                               \
          std::make_shared<Imm>(                                                                              \
              2, 21, Imm::Repr::Signed,                                                                       \
              std::vector{ImmPart(20, 31, 31), ImmPart(12, 12, 19), ImmPart(11, 20, 20), ImmPart(1, 21, 30)}, \
@@ -96,7 +96,7 @@ RV32I_Assembler::initInstructions(const ISAInfo<ISA::RV32I>* isa) const {
 #define JALRType(name)                                                                                \
     std::shared_ptr<Instruction>(                                                                     \
         new Instruction(Opcode(name, {OpPart(0b1100111, 0, 6), OpPart(0b000, 12, 14)}),               \
-                        {std::make_shared<Reg>(isa, 1, 7, 11, Reg::Regsd::rd), std::make_shared<Reg>(isa, 2, 15, 19, Reg::Regsd::rs1), \
+                        {std::make_shared<Reg>(isa, 1, 7, 11, "rd"), std::make_shared<Reg>(isa, 2, 15, 19, "rs1"), \
                          std::make_shared<Imm>(3, 12, Imm::Repr::Signed, std::vector{ImmPart(0, 20, 31)})}))
 
 #define RegTok PseudoInstruction::reg()
@@ -325,7 +325,7 @@ void RV32I_Assembler::enableExtI(const ISAInfo<ISA::RV32I>* isa, InstrVec& instr
     auto auipcSymbolModifier = [](uint32_t bareSymbol) { return bareSymbol >> 12; };
     instructions.push_back(std::shared_ptr<Instruction>(
         new Instruction(Opcode("auipc", {OpPart(0b0010111, 0, 6)}),
-                        {std::make_shared<Reg>(isa, 1, 7, 11, Reg::Regsd::rd),
+                        {std::make_shared<Reg>(isa, 1, 7, 11, "rd"),
                          std::make_shared<Imm>(2, 32, Imm::Repr::Hex, std::vector{ImmPart(0, 12, 31)},
                                                Imm::SymbolType::Absolute, auipcSymbolModifier)})));
 

--- a/src/assembler/rv32i_assembler.cpp
+++ b/src/assembler/rv32i_assembler.cpp
@@ -41,7 +41,7 @@ RV32I_Assembler::initInstructions(const ISAInfo<ISA::RV32I>* isa) const {
 #define BType(name, funct3)                                                                              \
     std::shared_ptr<Instruction>(new Instruction(                                                        \
         Opcode(name, {OpPart(0b1100011, 0, 6), OpPart(funct3, 12, 14)}),                                 \
-        {std::make_shared<Reg>(isa, 1, 15, 19), std::make_shared<Reg>(isa, 2, 20, 24),                   \
+        {std::make_shared<Reg>(isa, 1, 15, 19, Reg::Regsd::rs1), std::make_shared<Reg>(isa, 2, 20, 24, Reg::Regsd::rs2),                   \
          std::make_shared<Imm>(                                                                          \
              3, 13, Imm::Repr::Signed,                                                                   \
              std::vector{ImmPart(12, 31, 31), ImmPart(11, 7, 7), ImmPart(5, 25, 30), ImmPart(1, 8, 11)}, \
@@ -50,44 +50,44 @@ RV32I_Assembler::initInstructions(const ISAInfo<ISA::RV32I>* isa) const {
 #define IType(name, funct3)                                                                           \
     std::shared_ptr<Instruction>(                                                                     \
         new Instruction(Opcode(name, {OpPart(0b0010011, 0, 6), OpPart(funct3, 12, 14)}),              \
-                        {std::make_shared<Reg>(isa, 1, 7, 11), std::make_shared<Reg>(isa, 2, 15, 19), \
+                        {std::make_shared<Reg>(isa, 1, 7, 11, Reg::Regsd::rd), std::make_shared<Reg>(isa, 2, 15, 19, Reg::Regsd::rs1), \
                          std::make_shared<Imm>(3, 12, Imm::Repr::Signed, std::vector{ImmPart(0, 20, 31)})}))
 
 #define LoadType(name, funct3)                                                                        \
     std::shared_ptr<Instruction>(                                                                     \
         new Instruction(Opcode(name, {OpPart(0b0000011, 0, 6), OpPart(funct3, 12, 14)}),              \
-                        {std::make_shared<Reg>(isa, 1, 7, 11), std::make_shared<Reg>(isa, 3, 15, 19), \
+                        {std::make_shared<Reg>(isa, 1, 7, 11, Reg::Regsd::rd), std::make_shared<Reg>(isa, 3, 15, 19, Reg::Regsd::rs1), \
                          std::make_shared<Imm>(2, 12, Imm::Repr::Signed, std::vector{ImmPart(0, 20, 31)})}))
 
 #define IShiftType(name, funct3, funct7)                                                                         \
     std::shared_ptr<Instruction>(                                                                                \
         new Instruction(Opcode(name, {OpPart(0b0010011, 0, 6), OpPart(funct3, 12, 14), OpPart(funct7, 25, 31)}), \
-                        {std::make_shared<Reg>(isa, 1, 7, 11), std::make_shared<Reg>(isa, 2, 15, 19),            \
+                        {std::make_shared<Reg>(isa, 1, 7, 11, Reg::Regsd::rd), std::make_shared<Reg>(isa, 2, 15, 19, Reg::Regsd::rs1),            \
                          std::make_shared<Imm>(3, 5, Imm::Repr::Unsigned, std::vector{ImmPart(0, 20, 24)})}))
 
 #define RType(name, funct3, funct7)                                                                              \
     std::shared_ptr<Instruction>(                                                                                \
         new Instruction(Opcode(name, {OpPart(0b0110011, 0, 6), OpPart(funct3, 12, 14), OpPart(funct7, 25, 31)}), \
-                        {std::make_shared<Reg>(isa, 1, 7, 11), std::make_shared<Reg>(isa, 2, 15, 19),            \
-                         std::make_shared<Reg>(isa, 3, 20, 24)}))
+                        {std::make_shared<Reg>(isa, 1, 7, 11, Reg::Regsd::rd), std::make_shared<Reg>(isa, 2, 15, 19, Reg::Regsd::rs1),            \
+                         std::make_shared<Reg>(isa, 3, 20, 24, Reg::Regsd::rs2)}))
 
 #define SType(name, funct3)                                                                                   \
     std::shared_ptr<Instruction>(new Instruction(                                                             \
         Opcode(name, {OpPart(0b0100011, 0, 6), OpPart(funct3, 12, 14)}),                                      \
-        {std::make_shared<Reg>(isa, 3, 15, 19),                                                               \
+        {std::make_shared<Reg>(isa, 3, 15, 19, Reg::Regsd::rs1),                                                               \
          std::make_shared<Imm>(2, 12, Imm::Repr::Signed, std::vector{ImmPart(5, 25, 31), ImmPart(0, 7, 11)}), \
-         std::make_shared<Reg>(isa, 1, 20, 24)}))
+         std::make_shared<Reg>(isa, 1, 20, 24, Reg::Regsd::rs2)}))
 
 #define UType(name, opcode)                                    \
     std::shared_ptr<Instruction>(                              \
         new Instruction(Opcode(name, {OpPart(opcode, 0, 6)}),  \
-                        {std::make_shared<Reg>(isa, 1, 7, 11), \
+                        {std::make_shared<Reg>(isa, 1, 7, 11, Reg::Regsd::rd), \
                          std::make_shared<Imm>(2, 32, Imm::Repr::Hex, std::vector{ImmPart(0, 12, 31)})}))
 
 #define JType(name, opcode)                                                                                  \
     std::shared_ptr<Instruction>(new Instruction(                                                            \
         Opcode(name, {OpPart(opcode, 0, 6)}),                                                                \
-        {std::make_shared<Reg>(isa, 1, 7, 11),                                                               \
+        {std::make_shared<Reg>(isa, 1, 7, 11, Reg::Regsd::rd),                                                               \
          std::make_shared<Imm>(                                                                              \
              2, 21, Imm::Repr::Signed,                                                                       \
              std::vector{ImmPart(20, 31, 31), ImmPart(12, 12, 19), ImmPart(11, 20, 20), ImmPart(1, 21, 30)}, \
@@ -96,7 +96,7 @@ RV32I_Assembler::initInstructions(const ISAInfo<ISA::RV32I>* isa) const {
 #define JALRType(name)                                                                                \
     std::shared_ptr<Instruction>(                                                                     \
         new Instruction(Opcode(name, {OpPart(0b1100111, 0, 6), OpPart(0b000, 12, 14)}),               \
-                        {std::make_shared<Reg>(isa, 1, 7, 11), std::make_shared<Reg>(isa, 2, 15, 19), \
+                        {std::make_shared<Reg>(isa, 1, 7, 11, Reg::Regsd::rd), std::make_shared<Reg>(isa, 2, 15, 19, Reg::Regsd::rs1), \
                          std::make_shared<Imm>(3, 12, Imm::Repr::Signed, std::vector{ImmPart(0, 20, 31)})}))
 
 #define RegTok PseudoInstruction::reg()
@@ -325,7 +325,7 @@ void RV32I_Assembler::enableExtI(const ISAInfo<ISA::RV32I>* isa, InstrVec& instr
     auto auipcSymbolModifier = [](uint32_t bareSymbol) { return bareSymbol >> 12; };
     instructions.push_back(std::shared_ptr<Instruction>(
         new Instruction(Opcode("auipc", {OpPart(0b0010111, 0, 6)}),
-                        {std::make_shared<Reg>(isa, 1, 7, 11),
+                        {std::make_shared<Reg>(isa, 1, 7, 11, Reg::Regsd::rd),
                          std::make_shared<Imm>(2, 32, Imm::Repr::Hex, std::vector{ImmPart(0, 12, 31)},
                                                Imm::SymbolType::Absolute, auipcSymbolModifier)})));
 


### PR DESCRIPTION
Hi @mortbopet ,
Referring to your opinion, we have a little progress in implementing this issues.
We have added a parameter at the instruction definition for determining the type (Reg or Imm) in  rv32i_assembler.cpp.
Otherwise, we also add some code to represent our desired result in instruction.h.
![image](https://user-images.githubusercontent.com/68934440/104678215-e908b300-5725-11eb-9c04-bbb4fbef5178.png)
![image](https://user-images.githubusercontent.com/68934440/104678250-f625a200-5725-11eb-91b3-358853638550.png)
![image](https://user-images.githubusercontent.com/68934440/104678264-0178cd80-5726-11eb-9add-0d2118e92a3f.png)
