### PR TITLE
Support to programviewer pc highlight

### DIFF
--- a/src/programviewer.cpp
+++ b/src/programviewer.cpp
@@ -211,8 +211,21 @@ void ProgramViewer::breakpointAreaPaintEvent(QPaintEvent* event) {
 }
 
 QTextBlock ProgramViewer::blockForAddress(AInt addr) const {
-    const uint64_t adjustedLineNumber =
-        (addr - ProcessorHandler::get()->getTextStart()) / ProcessorHandler::currentISA()->instrBytes();
+    // const uint64_t adjustedLineNumber =
+    //    (addr - ProcessorHandler::get()->getTextStart()) / ProcessorHandler::currentISA()->instrBytes();
+
+    uint64_t adjustedLineNumber = 0;
+    auto m_program = ProcessorHandler::getProgram();
+    if (m_program) {
+        const AInt addrAdjusted = addr - m_program->getSection(TEXT_SECTION_NAME)->address;
+        auto& disassembleRes = m_program->getDisassembled();
+        auto it = disassembleRes.lower_bound(addrAdjusted);
+        if (it == disassembleRes.end()) {
+            adjustedLineNumber = 0;
+        } else {
+            adjustedLineNumber = std::distance(disassembleRes.begin(), it);
+        }
+    }
 
     if (m_labelAddrOffsetMap.empty()) {
         return document()->findBlockByNumber(adjustedLineNumber);


### PR DESCRIPTION
This PR only uses your instructionmodel code https://github.com/mortbopet/Ripes/blob/7dbf8df60a5d456db907fe663e4dc70891e6becc/src/instructionmodel.cpp#L21 to update de  calculation of the programviewer line number. 

For the current code of your disassemble_cache branch the cursor only works with assembly examples. For the C or elf examples the cursor is not update.

![cursor](https://user-images.githubusercontent.com/13749258/137650295-3bd25bc2-80ec-440f-8262-8eb91732f9ea.gif)
. 