### PR TITLE
fix tst_cosimulate to assemble on file load

### DIFF
--- a/test/tst_cosimulate.cpp
+++ b/test/tst_cosimulate.cpp
@@ -153,7 +153,7 @@ QString tst_Cosimulate::generateErrorReport(const RegisterChange& change, const 
 
 void tst_Cosimulate::loadCurrentTest() {
     // Some manual work is required here since we are not instantiating the full application
-    m_loader->loadFile(m_currentTest);
+    m_loader->loadExternalFile(m_currentTest);
     if (m_currentTest.type == SourceType::Assembly) {
         m_loader->sourceCodeChanged();
     }


### PR DESCRIPTION
Although it works with the github CI/CD, the tst_cosimulate test only worked locally on my computer after this modification. Without this modification the assembly file is internally recognized as C and is not assembled with `m_loader->sourceCodeChanged();`. 