### PR TITLE
Relax instruction alignment constraint when RVC is enabled

### DIFF
--- a/src/assembler/assembler.h
+++ b/src/assembler/assembler.h
@@ -380,25 +380,13 @@ protected:
 
                 /// Check if we're now misaligned wrt. the size of the instruction. Instructions should always be
                 /// emitted on an aligned boundary wrt. their size.
-                unsigned alignmentDiff;
-                if (m_isa->extensionEnabled("C")) {
-                    alignmentDiff = addr_offset % (assembledWith->size() / 2);
-                    if (alignmentDiff != 0) {
-                        errors.push_back(
-                            {line.sourceLine, "Instruction misaligned (" + QString::number(alignmentDiff * 8) +
-                                                  "-bit boundary). This instruction must be aligned on a " +
-                                                  QString::number((assembledWith->size() / 2) * 8) + "-bit boundary."});
-                        break;
-                    }
-                } else {
-                    alignmentDiff = addr_offset % assembledWith->size();
-                    if (alignmentDiff != 0) {
-                        errors.push_back(
-                            {line.sourceLine, "Instruction misaligned (" + QString::number(alignmentDiff * 8) +
-                                                  "-bit boundary). This instruction must be aligned on a " +
-                                                  QString::number(assembledWith->size() * 8) + "-bit boundary."});
-                        break;
-                    }
+                const unsigned alignmentDiff = addr_offset % (m_isa->instrByteAlignment());
+                if (alignmentDiff != 0) {
+                    errors.push_back({line.sourceLine, "Instruction misaligned (" + QString::number(alignmentDiff * 8) +
+                                                           "-bit boundary). This instruction must be aligned on a " +
+                                                           QString::number((m_isa->instrByteAlignment()) * 8) +
+                                                           "-bit boundary."});
+                    break;
                 }
 
                 currentSection->data.append(

--- a/src/assembler/assembler.h
+++ b/src/assembler/assembler.h
@@ -380,13 +380,25 @@ protected:
 
                 /// Check if we're now misaligned wrt. the size of the instruction. Instructions should always be
                 /// emitted on an aligned boundary wrt. their size.
-                unsigned alignmentDiff = addr_offset % assembledWith->size();
-                if (alignmentDiff != 0) {
-                    errors.push_back({line.sourceLine, "Instruction misaligned (" + QString::number(alignmentDiff * 8) +
-                                                           "-bit boundary). This instruction must be aligned on a " +
-                                                           QString::number(assembledWith->size() * 8) +
-                                                           "-bit boundary."});
-                    break;
+                unsigned alignmentDiff;
+                if (m_isa->extensionEnabled("C")) {
+                    alignmentDiff = addr_offset % (assembledWith->size() / 2);
+                    if (alignmentDiff != 0) {
+                        errors.push_back(
+                            {line.sourceLine, "Instruction misaligned (" + QString::number(alignmentDiff * 8) +
+                                                  "-bit boundary). This instruction must be aligned on a " +
+                                                  QString::number((assembledWith->size() / 2) * 8) + "-bit boundary."});
+                        break;
+                    }
+                } else {
+                    alignmentDiff = addr_offset % assembledWith->size();
+                    if (alignmentDiff != 0) {
+                        errors.push_back(
+                            {line.sourceLine, "Instruction misaligned (" + QString::number(alignmentDiff * 8) +
+                                                  "-bit boundary). This instruction must be aligned on a " +
+                                                  QString::number(assembledWith->size() * 8) + "-bit boundary."});
+                        break;
+                    }
                 }
 
                 currentSection->data.append(

--- a/src/isa/isainfo.h
+++ b/src/isa/isainfo.h
@@ -47,6 +47,7 @@ public:
     unsigned bytes() const { return bits() / CHAR_BIT; }            // Register width, in bytes
     virtual unsigned instrBits() const = 0;                         // Instruction width, in bits
     unsigned instrBytes() const { return instrBits() / CHAR_BIT; }  // Instruction width, in bytes
+    virtual unsigned instrByteAlignment() const { return 0; }       // Instruction Alignment, in bytes
     virtual int spReg() const { return -1; }                        // Stack pointer
     virtual int gpReg() const { return -1; }                        // Global pointer
     virtual int syscallReg() const { return -1; }                   // Syscall function register

--- a/src/isa/rv32isainfo.h
+++ b/src/isa/rv32isainfo.h
@@ -36,6 +36,13 @@ public:
         return march;
     }
     QString CCmabi() const override { return "ilp32"; }
+
+    unsigned instrByteAlignment() const {
+        if (extensionEnabled("C"))
+            return 2;
+        else
+            return 4;
+    };
 };
 
 }  // namespace Ripes

--- a/src/isa/rv32isainfo.h
+++ b/src/isa/rv32isainfo.h
@@ -37,7 +37,7 @@ public:
     }
     QString CCmabi() const override { return "ilp32"; }
 
-    unsigned instrByteAlignment() const { return extensionEnabled("C") ? 2 : 4; };
+    unsigned instrByteAlignment() const override { return extensionEnabled("C") ? 2 : 4; };
 };
 
 }  // namespace Ripes

--- a/src/isa/rv32isainfo.h
+++ b/src/isa/rv32isainfo.h
@@ -37,12 +37,7 @@ public:
     }
     QString CCmabi() const override { return "ilp32"; }
 
-    unsigned instrByteAlignment() const {
-        if (extensionEnabled("C"))
-            return 2;
-        else
-            return 4;
-    };
+    unsigned instrByteAlignment() const { return extensionEnabled("C") ? 2 : 4; };
 };
 
 }  // namespace Ripes

--- a/src/isa/rv64isainfo.h
+++ b/src/isa/rv64isainfo.h
@@ -35,6 +35,13 @@ public:
         return march;
     }
     QString CCmabi() const override { return "lp64"; }
+
+    unsigned instrByteAlignment() const {
+        if (extensionEnabled("C"))
+            return 2;
+        else
+            return 4;
+    };
 };
 
 }  // namespace Ripes

--- a/src/isa/rv64isainfo.h
+++ b/src/isa/rv64isainfo.h
@@ -36,7 +36,7 @@ public:
     }
     QString CCmabi() const override { return "lp64"; }
 
-    unsigned instrByteAlignment() const { return extensionEnabled("C") ? 2 : 4; };
+    unsigned instrByteAlignment() const override { return extensionEnabled("C") ? 2 : 4; };
 };
 
 }  // namespace Ripes

--- a/src/isa/rv64isainfo.h
+++ b/src/isa/rv64isainfo.h
@@ -36,12 +36,7 @@ public:
     }
     QString CCmabi() const override { return "lp64"; }
 
-    unsigned instrByteAlignment() const {
-        if (extensionEnabled("C"))
-            return 2;
-        else
-            return 4;
-    };
+    unsigned instrByteAlignment() const { return extensionEnabled("C") ? 2 : 4; };
 };
 
 }  // namespace Ripes

--- a/test/riscv-tests-c-64/rvc.s
+++ b/test/riscv-tests-c-64/rvc.s
@@ -239,6 +239,7 @@ test_35:
  c.j 4
  c.j fail
  c.nop
+ nop
  li t2,0
  li gp,35
  bne ra,t2,fail

--- a/test/riscv-tests-c-64/rvc.s
+++ b/test/riscv-tests-c-64/rvc.s
@@ -18,7 +18,6 @@ test_2:
     
 test_3:
  c.addi4spn a0,1020
- c.nop
  lui t2,0x1
  addi t2,t2,1584 
  li gp,3
@@ -26,7 +25,6 @@ test_3:
     
 test_4:
  c.addi16sp 496
- c.nop
  lui t2,0x1
  addi t2,t2,1060 
  li gp,4
@@ -35,7 +33,6 @@ test_4:
     
 test_5:
  c.addi16sp -512
- c.nop
  lui t2,0x1
  addi t2,t2,548
  li gp,5
@@ -72,18 +69,16 @@ test_7:
 test_8:
  ori a0,zero,1
  c.addi a0,-16
- c.nop
  li t2,-15
  li gp,8
  bne a0,t2, fail 
  
 test_9:
-  ori a5,zero,1
+ ori a5,zero,1
  c.li a5,-16
- c.nop
-  li t2,-16
+ li t2,-16
  li gp,9
-  bne a5,t2, fail
+ bne a5,t2, fail
 
 test_10:
  c.ld a0,a1,0 #c.ld a0, 0(a1)
@@ -120,7 +115,6 @@ test_15:
  c.li s1,20
  c.li a0,6
  c.sub s1,a0
- c.nop
  li t2,14
  li gp,15
  bne s1,t2, fail
@@ -129,7 +123,6 @@ test_16:
  c.li s1,20
  c.li a0,6
  c.xor s1,a0
- c.nop
  li t2,18
  li gp,16
  bne s1,t2, fail
@@ -138,7 +131,6 @@ test_17:
  c.li s1,20
  c.li a0,6
  c.or s1,a0
- c.nop
  li t2,22
  li gp,17
  bne s1,t2, fail
@@ -147,7 +139,6 @@ test_18:
  c.li s1,20
  c.li a0,6
  c.and s1,a0
- c.nop
  li t2,4
  li gp,18
  bne s1,t2, fail
@@ -174,7 +165,6 @@ test_21:
  lui s0,0x1
  addi s0,s0,564 
  c.slli s0,0x4
- c.nop
  lui t2,0x12
  addi t2,t2,832 
  li gp,21
@@ -186,7 +176,6 @@ test_30:
  c.j 4
  c.j 4
  c.j fail
- c.nop
  li t2,0
  li gp,30
  bne ra,t2, fail
@@ -197,8 +186,7 @@ test_31:
  c.j 4
  c.j 4
  c.j fail
- c.nop
-  li t2,0
+ li t2,0
  li gp,31
  bne zero,t2, fail
 
@@ -208,7 +196,6 @@ test_32:
  c.j 4
  c.j 4
  c.j fail
- c.nop
  li t2,0
  li gp,32
  bne zero,t2, fail
@@ -239,8 +226,6 @@ test_35:
  c.j 4
  c.j 4
  c.j fail
- c.nop
- nop
  li t2,0
  li gp,35
  bne ra,t2,fail
@@ -253,7 +238,6 @@ test_36:
  c.j 4
  c.j 4
  c.j fail
- c.nop
  sub ra,ra,t0
  li t2,-2
  li gp,36

--- a/test/riscv-tests-c-64/rvc.s
+++ b/test/riscv-tests-c-64/rvc.s
@@ -25,6 +25,7 @@ test_3:
     
 test_4:
  c.addi16sp 496
+ c.nop
  lui t2,0x1
  addi t2,t2,1060 
  li gp,4
@@ -33,6 +34,7 @@ test_4:
     
 test_5:
  c.addi16sp -512
+ c.nop
  lui t2,0x1
  addi t2,t2,548
  li gp,5
@@ -69,6 +71,7 @@ test_7:
 test_8:
  ori a0,zero,1
  c.addi a0,-16
+ c.nop
  li t2,-15
  li gp,8
  bne a0,t2, fail 
@@ -76,6 +79,7 @@ test_8:
 test_9:
  ori a5,zero,1
  c.li a5,-16
+ c.nop
  li t2,-16
  li gp,9
  bne a5,t2, fail
@@ -115,6 +119,7 @@ test_15:
  c.li s1,20
  c.li a0,6
  c.sub s1,a0
+ c.nop
  li t2,14
  li gp,15
  bne s1,t2, fail
@@ -123,6 +128,7 @@ test_16:
  c.li s1,20
  c.li a0,6
  c.xor s1,a0
+ c.nop
  li t2,18
  li gp,16
  bne s1,t2, fail
@@ -131,6 +137,7 @@ test_17:
  c.li s1,20
  c.li a0,6
  c.or s1,a0
+ c.nop
  li t2,22
  li gp,17
  bne s1,t2, fail
@@ -139,6 +146,7 @@ test_18:
  c.li s1,20
  c.li a0,6
  c.and s1,a0
+ c.nop
  li t2,4
  li gp,18
  bne s1,t2, fail
@@ -165,6 +173,7 @@ test_21:
  lui s0,0x1
  addi s0,s0,564 
  c.slli s0,0x4
+ c.nop
  lui t2,0x12
  addi t2,t2,832 
  li gp,21
@@ -176,6 +185,7 @@ test_30:
  c.j 4
  c.j 4
  c.j fail
+ c.nop
  li t2,0
  li gp,30
  bne ra,t2, fail
@@ -186,6 +196,7 @@ test_31:
  c.j 4
  c.j 4
  c.j fail
+ c.nop
  li t2,0
  li gp,31
  bne zero,t2, fail
@@ -196,6 +207,7 @@ test_32:
  c.j 4
  c.j 4
  c.j fail
+ c.nop
  li t2,0
  li gp,32
  bne zero,t2, fail
@@ -226,6 +238,7 @@ test_35:
  c.j 4
  c.j 4
  c.j fail
+ c.nop
  li t2,0
  li gp,35
  bne ra,t2,fail
@@ -239,6 +252,7 @@ test_36:
  c.j 4
  c.j fail
  sub ra,ra,t0
+ c.nop
  li t2,-2
  li gp,36
  bne ra,t2,fail

--- a/test/riscv-tests-c/rvc.s
+++ b/test/riscv-tests-c/rvc.s
@@ -25,6 +25,7 @@ test_3:
     
 test_4:
  c.addi16sp 496
+ c.nop 
  lui t2,0x1
  addi t2,t2,1060 
  li gp,4
@@ -33,6 +34,7 @@ test_4:
     
 test_5:
  c.addi16sp -512
+ c.nop
  lui t2,0x1
  addi t2,t2,548
  li gp,5
@@ -53,6 +55,7 @@ test_6:
 test_8:
  ori a0,zero,1
  c.addi a0,-16
+ c.nop
  li t2,-15
  li gp,8
  bne a0,t2, fail 
@@ -60,6 +63,7 @@ test_8:
 test_9:
  ori a5,zero,1
  c.li a5,-16
+ c.nop
  li t2,-16
  li gp,9
  bne a5,t2, fail
@@ -90,6 +94,7 @@ test_15:
  c.li s1,20
  c.li a0,6
  c.sub s1,a0
+ c.nop
  li t2,14
  li gp,15
  bne s1,t2, fail
@@ -98,6 +103,7 @@ test_16:
  c.li s1,20
  c.li a0,6
  c.xor s1,a0
+ c.nop
  li t2,18
  li gp,16
  bne s1,t2, fail
@@ -106,6 +112,7 @@ test_17:
  c.li s1,20
  c.li a0,6
  c.or s1,a0
+ c.nop
  li t2,22
  li gp,17
  bne s1,t2, fail
@@ -114,6 +121,7 @@ test_18:
  c.li s1,20
  c.li a0,6
  c.and s1,a0
+ c.nop
  li t2,4
  li gp,18
  bne s1,t2, fail
@@ -122,6 +130,7 @@ test_21:
  lui s0,0x1
  addi s0,s0,564 
  c.slli s0,0x4
+ c.nop
  lui t2,0x12
  addi t2,t2,832 
  li gp,21
@@ -133,6 +142,7 @@ test_30:
  c.j 4
  c.j 4
  c.j fail
+ c.nop
  li t2,0
  li gp,30
  bne ra,t2, fail
@@ -143,6 +153,7 @@ test_31:
  c.j 4
  c.j 4
  c.j fail
+ c.nop
  li t2,0
  li gp,31
  bne zero,t2, fail
@@ -153,6 +164,7 @@ test_32:
  c.j 4
  c.j 4
  c.j fail
+ c.nop
  li t2,0
  li gp,32
  bne zero,t2, fail
@@ -183,6 +195,7 @@ test_35:
  c.j 4
  c.j 4
  c.j fail
+ c.nop
  li t2,0
  li gp,35
  bne ra,t2,fail
@@ -196,6 +209,7 @@ test_36:
  c.j 4
  c.j fail
  sub ra,ra,t0
+ c.nop
  li t2,-2
  li gp,36
  bne ra,t2,fail
@@ -209,6 +223,7 @@ test_37:
  c.j 4
  c.j fail
  sub ra,ra,t0
+ c.nop
  li t2,-2
  li gp,37
  bne ra,t2,fail

--- a/test/riscv-tests-c/rvc.s
+++ b/test/riscv-tests-c/rvc.s
@@ -18,7 +18,6 @@ test_2:
     
 test_3:
  c.addi4spn a0,1020
- c.nop
  lui t2,0x1
  addi t2,t2,1584 
  li gp,3
@@ -26,7 +25,6 @@ test_3:
     
 test_4:
  c.addi16sp 496
- c.nop
  lui t2,0x1
  addi t2,t2,1060 
  li gp,4
@@ -35,7 +33,6 @@ test_4:
     
 test_5:
  c.addi16sp -512
- c.nop
  lui t2,0x1
  addi t2,t2,548
  li gp,5
@@ -56,7 +53,6 @@ test_6:
 test_8:
  ori a0,zero,1
  c.addi a0,-16
- c.nop
  li t2,-15
  li gp,8
  bne a0,t2, fail 
@@ -64,7 +60,6 @@ test_8:
 test_9:
  ori a5,zero,1
  c.li a5,-16
- c.nop
  li t2,-16
  li gp,9
  bne a5,t2, fail
@@ -95,7 +90,6 @@ test_15:
  c.li s1,20
  c.li a0,6
  c.sub s1,a0
- c.nop
  li t2,14
  li gp,15
  bne s1,t2, fail
@@ -104,7 +98,6 @@ test_16:
  c.li s1,20
  c.li a0,6
  c.xor s1,a0
- c.nop
  li t2,18
  li gp,16
  bne s1,t2, fail
@@ -113,7 +106,6 @@ test_17:
  c.li s1,20
  c.li a0,6
  c.or s1,a0
- c.nop
  li t2,22
  li gp,17
  bne s1,t2, fail
@@ -122,7 +114,6 @@ test_18:
  c.li s1,20
  c.li a0,6
  c.and s1,a0
- c.nop
  li t2,4
  li gp,18
  bne s1,t2, fail
@@ -131,7 +122,6 @@ test_21:
  lui s0,0x1
  addi s0,s0,564 
  c.slli s0,0x4
- c.nop
  lui t2,0x12
  addi t2,t2,832 
  li gp,21
@@ -143,7 +133,6 @@ test_30:
  c.j 4
  c.j 4
  c.j fail
- c.nop
  li t2,0
  li gp,30
  bne ra,t2, fail
@@ -154,7 +143,6 @@ test_31:
  c.j 4
  c.j 4
  c.j fail
- c.nop
  li t2,0
  li gp,31
  bne zero,t2, fail
@@ -165,7 +153,6 @@ test_32:
  c.j 4
  c.j 4
  c.j fail
- c.nop
  li t2,0
  li gp,32
  bne zero,t2, fail
@@ -196,8 +183,6 @@ test_35:
  c.j 4
  c.j 4
  c.j fail
- c.nop
- nop
  li t2,0
  li gp,35
  bne ra,t2,fail
@@ -210,7 +195,6 @@ test_36:
  c.j 4
  c.j 4
  c.j fail
- c.nop
  sub ra,ra,t0
  li t2,-2
  li gp,36
@@ -224,7 +208,6 @@ test_37:
  c.j 4
  c.j 4
  c.j fail
- c.nop
  sub ra,ra,t0
  li t2,-2
  li gp,37

--- a/test/riscv-tests-c/rvc.s
+++ b/test/riscv-tests-c/rvc.s
@@ -196,6 +196,7 @@ test_35:
  c.j 4
  c.j fail
  c.nop
+ nop
  li t2,0
  li gp,35
  bne ra,t2,fail


### PR DESCRIPTION
This PR implement the instruction alignment constraint relax tho 16bits when RVC is enabled and remove the `c.nop` pad instructions from tests. It will close https://github.com/mortbopet/Ripes/issues/124.