### PR TITLE
Add clang-format support #181

### DIFF
--- a/src/ccmanager.cpp
+++ b/src/ccmanager.cpp
@@ -4,6 +4,7 @@
 #include "loaddialog.h"
 #include "processorhandler.h"
 #include "ripessettings.h"
+#include "utilities/systemutils.h"
 
 #include <QProcess>
 #include <QProgressDialog>
@@ -60,18 +61,9 @@ bool CCManager::hasValidCC() {
 }
 
 QString CCManager::tryAutodetectCC() {
-    for (const auto& path : s_validAutodetectedCCs) {
-        QProcess process;
-
-        process.start(path, QStringList());
-        process.waitForFinished();
-
-        if (process.error() != QProcess::FailedToStart) {
-            // We have detected that a valid compiler exists in path
-            return path;
-        }
-    }
-
+    auto ccIt = llvm::find_if(s_validAutodetectedCCs, [&](const QString& path) { return isExecutable(path); });
+    if (ccIt != s_validAutodetectedCCs.end())
+        return *ccIt;
     return QString();
 }
 

--- a/src/editor/codeeditor.cpp
+++ b/src/editor/codeeditor.cpp
@@ -87,8 +87,14 @@ void CodeEditor::onSave() {
     if (!FormatterManager::hasValidProgram())
         return;
 
+    // We want to execute the formatter in the savefile's directory to adhere to any formatting config files.
+    auto savePath = RipesSettings::value(RIPES_SETTING_SAVEPATH).toString();
+    if (savePath.isEmpty())
+        return;
+
+    auto tmpDir = QFileInfo(savePath).dir();
     const auto tempFileTemplate =
-        QString(QDir::tempPath() + QDir::separator() + QCoreApplication::applicationName() + ".XXXXXX.c");
+        QString(tmpDir.path() + QDir::separator() + QCoreApplication::applicationName() + ".XXXXXX.c");
     QTemporaryFile tmpSrc(tempFileTemplate);
     tmpSrc.setAutoRemove(true);
     if (tmpSrc.open()) {

--- a/src/editor/codeeditor.cpp
+++ b/src/editor/codeeditor.cpp
@@ -102,7 +102,12 @@ void CodeEditor::onSave() {
         clangFormatArgs << tmpSrc.fileName();
         auto [stdOut, stdErr] = FormatterManager::run(clangFormatArgs);
         if (!stdErr.isEmpty()) {
-            GeneralStatusManager::setStatusTimed("Error while running 'clang-format': " + stdErr, 2000);
+            QMessageBox::warning(this, "Ripes",
+                                 "Error while executing formatter. Make sure the formatter path points to a "
+                                 "valid version of clang-format\n"
+                                 "Error message was:\n" +
+                                     stdErr,
+                                 QMessageBox::Ok);
             return;
         }
 

--- a/src/editor/codeeditor.h
+++ b/src/editor/codeeditor.h
@@ -30,6 +30,7 @@ public:
     int lineNumberAreaWidth();
     void setupChangedTimer();
     void rehighlight();
+    void onSave();
 
     void setErrors(const std::shared_ptr<Assembler::Errors>& errors) { m_errors = errors; }
 

--- a/src/edittab.cpp
+++ b/src/edittab.cpp
@@ -131,6 +131,10 @@ void EditTab::showSymbolNavigator() {
     }
 }
 
+void EditTab::onSave() {
+    m_ui->codeEditor->onSave();
+}
+
 bool EditTab::loadExternalFile(const LoadFileParams& params) {
     if (params.type == SourceType::C) {
         // Try to enable C input and verify that source type was changed successfully. This allows us to trigger the

--- a/src/edittab.h
+++ b/src/edittab.h
@@ -48,6 +48,7 @@ signals:
     void editorStateChanged(bool enabled);
 
 public slots:
+    void onSave();
     void onProcessorChanged();
     void updateProgramViewerHighlighting();
 

--- a/src/formattermanager.h
+++ b/src/formattermanager.h
@@ -12,7 +12,7 @@ class FormatterManager : public ProcessManager<FormatterManager> {
 
 private:
     bool verifyProgram(const QString& path) { return true; }
-    QString getSettingsPath() { return QString(); }
+    QString getSettingsPath() { return RIPES_SETTING_FORMATTER_PATH; }
     QStringList getAlwaysArguments() {
         return RipesSettings::value(RIPES_SETTING_FORMATTER_ARGS).toString().split(" ");
     }

--- a/src/formattermanager.h
+++ b/src/formattermanager.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <QCoreApplication>
+
+#include "processmanager.h"
+#include "ripessettings.h"
+
+namespace Ripes {
+
+class FormatterManager : public ProcessManager<FormatterManager> {
+    friend class ProcessManager<FormatterManager>;
+
+private:
+    bool verifyProgram(const QString& path) { return true; }
+    QString getSettingsPath() { return QString(); }
+    QStringList getAlwaysArguments() {
+        return RipesSettings::value(RIPES_SETTING_FORMATTER_ARGS).toString().split(" ");
+    }
+    QStringList getDefaultPaths() { return {"clang-format"}; }
+    QString getWorkingDirectory() { return QCoreApplication::applicationDirPath(); }
+};
+
+}  // namespace Ripes

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -118,6 +118,8 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent), m_ui(new Ui::Main
 
     connect(cacheTab, &CacheTab::focusAddressChanged, memoryTab, &MemoryTab::setCentralAddress);
 
+    connect(this, &MainWindow::prepareSave, editTab, &EditTab::onSave);
+
     m_currentTabID = ProcessorTabID;
     m_ui->tabbar->setActiveIndex(m_currentTabID);
 }
@@ -348,6 +350,8 @@ void MainWindow::saveFilesTriggered() {
         saveFilesAsTriggered();
         return;
     }
+
+    emit prepareSave();
 
     bool didSave = false;
     QStringList savedFiles;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -40,6 +40,9 @@ public:
     void closeEvent(QCloseEvent* event) override;
     void fitToView();
 
+signals:
+    void prepareSave();
+
 private slots:
     void wiki();
     void version();

--- a/src/processmanager.h
+++ b/src/processmanager.h
@@ -1,0 +1,118 @@
+#pragma once
+
+#include <QObject>
+#include <QProcess>
+#include <QProgressDialog>
+#include <QString>
+
+#include "ripessettings.h"
+#include "utilities/systemutils.h"
+
+namespace Ripes {
+
+// A process manager is responsible for managing the autodetection and execution of processes. A program manager is a
+// singleton for each specialization of the template. This is done through static polymorphism.
+template <typename Impl>
+class ProcessManager {
+public:
+    struct ProcessResult {
+        QString stdOut;
+        QString stdErr;
+    };
+    ProcessManager() { initialize(); }
+    virtual ~ProcessManager() = default;
+
+    static bool hasValidProgram() { return !get().m_programPath.isEmpty(); }
+    static const QString& program() { return get().m_programPath; }
+    static QString getError() { return get().m_error; }
+    static ProcessResult run(const QStringList& args, bool showProgressDialog = false) {
+        return get()._run(args, showProgressDialog);
+    }
+
+    static Impl& get() {
+        static Impl instance;
+        return instance;
+    }
+
+signals:
+
+    bool trySetProgram(const QString& path) {
+        if (static_cast<Impl*>(this)->verifyProgram(path)) {
+            m_programPath = path;
+        } else {
+            m_programPath = QString();
+        }
+        return !m_programPath.isEmpty();
+    }
+
+protected:
+    QString m_programPath;
+    QProcess m_process;
+    bool m_errored = false;
+    bool m_aborted = false;
+
+private:
+    // Tries to set the program from a set of optional default program names. These program names are expected to be
+    // found in the PATH.
+    bool tryAutodetectProgram() {
+        for (auto defaultPath : static_cast<Impl*>(this)->getDefaultPaths()) {
+            if (trySetProgram(defaultPath))
+                return true;
+        }
+        return false;
+    }
+
+    // Initializes the program.
+    bool initialize() {
+        auto settingsPath = static_cast<Impl*>(this)->getSettingsPath();
+        if (!settingsPath.isEmpty() && RipesSettings::hasSetting(settingsPath)) {
+            auto settingsPathValue = RipesSettings::value<QString>(settingsPath);
+            if (trySetProgram(settingsPathValue)) {
+                m_programPath = settingsPathValue;
+                return true;
+            }
+        }
+
+        // Couldn't initialize from settings, try autodetecting.
+        return tryAutodetectProgram();
+    }
+
+    // Run the program with a set of arguments.
+    ProcessResult _run(const QStringList& args, bool showProgressDialog) {
+        /**
+         * 1. m_process will itself spawn its own thread to execute the compiler.
+         * 2. QProcess should not be started in a separate QThread, so it is started in the gui thread
+         * 3. We want to execute a progress dialog which may abort the QProcess.
+         * 4. To facilitate all of this, we have to spin on the process state in a separate thread, to
+         *    not block the execution of the progress dialog.
+         */
+        m_aborted = false;
+        m_errored = false;
+        m_process.close();
+        QProgressDialog progressDiag = QProgressDialog("Executing program...", "Abort", 0, 0, nullptr);
+        m_process.connect(&progressDiag, &QProgressDialog::canceled, &m_process, &QProcess::kill);
+        m_process.connect(&progressDiag, &QProgressDialog::canceled, &m_process, [this] { m_aborted = true; });
+        m_process.connect(&m_process, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), &progressDiag,
+                          &QProgressDialog::reset);
+        m_process.connect(&m_process, &QProcess::errorOccurred, &progressDiag, &QProgressDialog::reset);
+        m_process.connect(&m_process, &QProcess::errorOccurred, [this]() { m_errored = true; });
+        m_process.setWorkingDirectory(static_cast<Impl*>(this)->getWorkingDirectory());
+        m_process.setProgram(m_programPath);
+        QStringList allArgs = static_cast<Impl*>(this)->getAlwaysArguments();
+        allArgs.append(args);
+        m_process.setArguments(allArgs);
+
+        m_process.start();
+        /** @todo: It is seen that if the process fails upon startup, errorOccurred executes QProgressDialog::reset.
+         * However, this call does not prevent the exec() loop from running. Below we check for this case, however this
+         * does not remove the race condition. Such race condition seems inherintly tied to how QDialog::exec works and
+         * no proper fix has been able to be found (yet).*/
+        if (!m_errored && showProgressDialog) {
+            progressDiag.exec();
+        }
+        m_process.waitForFinished();
+        return ProcessResult{QString(m_process.readAllStandardOutput()), QString(m_process.readAllStandardError())};
+    }
+};
+
+}  // namespace Ripes

--- a/src/processmanager.h
+++ b/src/processmanager.h
@@ -66,11 +66,15 @@ private:
     bool initialize() {
         auto settingsPath = static_cast<Impl*>(this)->getSettingsPath();
         if (!settingsPath.isEmpty() && RipesSettings::hasSetting(settingsPath)) {
+            // This program has a settings path associated with it. Link up with the settings path, ensuring that we
+            // update and revalidate the program on each settings path change.
+            auto* observer = RipesSettings::getObserver(settingsPath);
+            observer->connect(observer, &SettingObserver::modified,
+                              [&](const QVariant& value) { trySetProgram(value.toString()); });
+
             auto settingsPathValue = RipesSettings::value<QString>(settingsPath);
-            if (trySetProgram(settingsPathValue)) {
-                m_programPath = settingsPathValue;
+            if (trySetProgram(settingsPathValue))
                 return true;
-            }
         }
 
         // Couldn't initialize from settings, try autodetecting.

--- a/src/ripessettings.cpp
+++ b/src/ripessettings.cpp
@@ -12,6 +12,8 @@ const std::map<QString, QVariant> s_defaultSettings = {
     // User-modifyable settings
     {RIPES_SETTING_REWINDSTACKSIZE, 100},
     {RIPES_SETTING_CCPATH, ""},
+    {RIPES_SETTING_FORMAT_ON_SAVE, true},
+    {RIPES_SETTING_FORMATTER_ARGS, "--style=LLVM"},
     {RIPES_SETTING_CCARGS, "-O0"},
     {RIPES_SETTING_LDARGS, "-static -lm"},  // Ensure statically linked executable + link with math library
     {RIPES_SETTING_CONSOLEECHO, "true"},

--- a/src/ripessettings.cpp
+++ b/src/ripessettings.cpp
@@ -13,8 +13,8 @@ const std::map<QString, QVariant> s_defaultSettings = {
     {RIPES_SETTING_REWINDSTACKSIZE, 100},
     {RIPES_SETTING_CCPATH, ""},
     {RIPES_SETTING_FORMATTER_PATH, "clang-format"},
-    {RIPES_SETTING_FORMAT_ON_SAVE, true},
-    {RIPES_SETTING_FORMATTER_ARGS, "--style=LLVM"},
+    {RIPES_SETTING_FORMAT_ON_SAVE, false},
+    {RIPES_SETTING_FORMATTER_ARGS, "--style=file --fallback-style=LLVM"},
     {RIPES_SETTING_CCARGS, "-O0"},
     {RIPES_SETTING_LDARGS, "-static -lm"},  // Ensure statically linked executable + link with math library
     {RIPES_SETTING_CONSOLEECHO, "true"},

--- a/src/ripessettings.cpp
+++ b/src/ripessettings.cpp
@@ -12,6 +12,7 @@ const std::map<QString, QVariant> s_defaultSettings = {
     // User-modifyable settings
     {RIPES_SETTING_REWINDSTACKSIZE, 100},
     {RIPES_SETTING_CCPATH, ""},
+    {RIPES_SETTING_FORMATTER_PATH, "clang-format"},
     {RIPES_SETTING_FORMAT_ON_SAVE, true},
     {RIPES_SETTING_FORMATTER_ARGS, "--style=LLVM"},
     {RIPES_SETTING_CCARGS, "-O0"},

--- a/src/ripessettings.h
+++ b/src/ripessettings.h
@@ -11,6 +11,7 @@ namespace Ripes {
 #define RIPES_SETTING_REWINDSTACKSIZE ("simulator_rewindstacksize")
 #define RIPES_SETTING_CCPATH ("compiler_path")
 #define RIPES_SETTING_CCARGS ("compiler_args")
+#define RIPES_SETTING_FORMATTER_PATH ("formatter_path")
 #define RIPES_SETTING_FORMAT_ON_SAVE ("format_on_save")
 #define RIPES_SETTING_FORMATTER_ARGS ("formatter_args")
 #define RIPES_SETTING_LDARGS ("linker_args")

--- a/src/ripessettings.h
+++ b/src/ripessettings.h
@@ -11,6 +11,8 @@ namespace Ripes {
 #define RIPES_SETTING_REWINDSTACKSIZE ("simulator_rewindstacksize")
 #define RIPES_SETTING_CCPATH ("compiler_path")
 #define RIPES_SETTING_CCARGS ("compiler_args")
+#define RIPES_SETTING_FORMAT_ON_SAVE ("format_on_save")
+#define RIPES_SETTING_FORMATTER_ARGS ("formatter_args")
 #define RIPES_SETTING_LDARGS ("linker_args")
 #define RIPES_SETTING_CONSOLEECHO ("console_echo")
 #define RIPES_SETTING_CONSOLEBG ("console_bg_color")

--- a/src/settingsdialog.cpp
+++ b/src/settingsdialog.cpp
@@ -2,6 +2,7 @@
 #include "ui_settingsdialog.h"
 
 #include "ccmanager.h"
+#include "formattermanager.h"
 #include "ripessettings.h"
 
 #include <QCheckBox>
@@ -301,6 +302,23 @@ QWidget* SettingsDialog::createEditorPage() {
     appendToLayout({consoleLabel, consoleCheckbox}, pageLayout,
                    "Show (or hide) a view of the console in the editor tab.");
 
+    // ===== Source formatter
+    auto* formatterGroupBox = new QGroupBox("Formatter");
+    appendToLayout(formatterGroupBox, pageLayout);
+    auto* formatterLayout = new QGridLayout();
+    auto* formatterDesc =
+        new QLabel("If clang-format is found in PATH, formatting will be applied upon saving a .c file.");
+    formatterDesc->setWordWrap(true);
+    appendToLayout(formatterDesc, formatterLayout);
+    formatterGroupBox->setLayout(formatterLayout);
+
+    // Format on save
+    appendToLayout(createSettingsWidgets<QCheckBox>(RIPES_SETTING_FORMAT_ON_SAVE, "Format on save:"), formatterLayout);
+
+    // Formatter arguments
+    appendToLayout(createSettingsWidgets<QLineEdit>(RIPES_SETTING_FORMATTER_ARGS, "Formatter arguments:"),
+                   formatterLayout);
+
     return pageWidget;
 }
 
@@ -359,8 +377,12 @@ QWidget* SettingsDialog::createEnvironmentPage() {
     return pageWidget;
 }
 
-void SettingsDialog::appendToLayout(QGroupBox* groupBox, QGridLayout* pageLayout, int colSpan) {
-    pageLayout->addWidget(groupBox, pageLayout->rowCount(), 0, 1, colSpan);
+void SettingsDialog::appendToLayout(QLayout* layout, QGridLayout* pageLayout, int colSpan) {
+    pageLayout->addLayout(layout, pageLayout->rowCount(), 0, 1, colSpan);
+}
+
+void SettingsDialog::appendToLayout(QWidget* widget, QGridLayout* pageLayout, int colSpan) {
+    pageLayout->addWidget(widget, pageLayout->rowCount(), 0, 1, colSpan);
 }
 
 void SettingsDialog::appendToLayout(std::pair<QLabel*, QWidget*> settingsWidgets, QGridLayout* pageLayout,

--- a/src/settingsdialog.cpp
+++ b/src/settingsdialog.cpp
@@ -306,11 +306,27 @@ QWidget* SettingsDialog::createEditorPage() {
     auto* formatterGroupBox = new QGroupBox("Formatter");
     appendToLayout(formatterGroupBox, pageLayout);
     auto* formatterLayout = new QGridLayout();
-    auto* formatterDesc =
-        new QLabel("If clang-format is found in PATH, formatting will be applied upon saving a .c file.");
+    auto* formatterDesc = new QLabel("Format .c files using clang-format, if available.");
     formatterDesc->setWordWrap(true);
     appendToLayout(formatterDesc, formatterLayout);
     formatterGroupBox->setLayout(formatterLayout);
+
+    // Formatter path
+    auto* FormatterPathLayout = new QHBoxLayout();
+    auto [formatterlabel, formatterpath] =
+        createSettingsWidgets<QLineEdit>(RIPES_SETTING_FORMATTER_PATH, "clang-format path:");
+    appendToLayout(FormatterPathLayout, formatterLayout);
+    FormatterPathLayout->addWidget(formatterlabel);
+    FormatterPathLayout->addWidget(formatterpath);
+    auto* pathBrowseButton = new QPushButton("Browse");
+    FormatterPathLayout->addWidget(pathBrowseButton);
+    connect(pathBrowseButton, &QPushButton::clicked, formatterpath, [=, formatterpath = formatterpath] {
+        QFileDialog dialog(this);
+        dialog.setAcceptMode(QFileDialog::AcceptOpen);
+        if (dialog.exec()) {
+            formatterpath->setText(dialog.selectedFiles().at(0));
+        }
+    });
 
     // Format on save
     appendToLayout(createSettingsWidgets<QCheckBox>(RIPES_SETTING_FORMAT_ON_SAVE, "Format on save:"), formatterLayout);

--- a/src/settingsdialog.h
+++ b/src/settingsdialog.h
@@ -45,7 +45,8 @@ private:
     void addPage(const QString& name, QWidget* page);
     void appendToLayout(std::pair<QLabel*, QWidget*> settingsWidgets, QGridLayout* pageLayout,
                         const QString& description = QString());
-    void appendToLayout(QGroupBox* groupBox, QGridLayout* pageLayout, int colSpan = 2);
+    void appendToLayout(QWidget* widget, QGridLayout* pageLayout, int colSpan = 2);
+    void appendToLayout(QLayout* layout, QGridLayout* pageLayout, int colSpan = 2);
 
     std::map<QString, int> m_pageIndex;
 };

--- a/src/utilities/systemutils.cpp
+++ b/src/utilities/systemutils.cpp
@@ -1,0 +1,12 @@
+#include "systemutils.h"
+
+#include <QProcess>
+namespace Ripes {
+bool isExecutable(const QString& path, const QStringList& dummyArgs) {
+    QProcess process;
+    process.start(path, dummyArgs);
+    process.waitForFinished();
+    return (process.error() != QProcess::FailedToStart);
+}
+
+}  // namespace Ripes

--- a/src/utilities/systemutils.h
+++ b/src/utilities/systemutils.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <QStringList>
+
+namespace Ripes {
+
+bool isExecutable(const QString& path, const QStringList& dummyArgs = {});
+
+}  // namespace Ripes


### PR DESCRIPTION
This commit adds support for running clang-format on C source code. `clang-format` must be available in PATH.