### PR TITLE
Fix bgtu and bleu pseudo-instructions to swap tokens correctly

### DIFF
--- a/src/assembler/rv_i_ext.h
+++ b/src/assembler/rv_i_ext.h
@@ -159,12 +159,12 @@ struct RV_I {
 
     pseudoInstructions.push_back(std::shared_ptr<_PseudoInstruction>(
         new _PseudoInstruction(Token("bgtu"), {RegTok, RegTok, ImmTok}, _PseudoExpandFunc(line) {
-            return LineTokensVec{LineTokens{Token("bltu"), line.tokens.at(2), line.tokens.at(2), line.tokens.at(3)}};
+            return LineTokensVec{LineTokens{Token("bltu"), line.tokens.at(2), line.tokens.at(1), line.tokens.at(3)}};
         })));
 
     pseudoInstructions.push_back(std::shared_ptr<_PseudoInstruction>(
         new _PseudoInstruction(Token("bleu"), {RegTok, RegTok, ImmTok}, _PseudoExpandFunc(line) {
-            return LineTokensVec{LineTokens{Token("bgeu"), line.tokens.at(2), line.tokens.at(2), line.tokens.at(3)}};
+            return LineTokensVec{LineTokens{Token("bgeu"), line.tokens.at(2), line.tokens.at(1), line.tokens.at(3)}};
         })));
         // clang-format on
 


### PR DESCRIPTION
The bgtu and bleu instructions were using the same token twice when generating the corresponding instruction. This was fixed by correctly swapping the first two tokens of these pseudo-instructions as expected.