### PR TITLE
Fix offset of compressed instructions c.bnez and c.beqz

### DIFF
--- a/src/processors/RISC-V/rv_uncompress.h
+++ b/src/processors/RISC-V/rv_uncompress.h
@@ -297,7 +297,7 @@ public:
                         case 0b010: {  // c.lwsp
                             const auto fields = RVInstrParser::getParser()->decodeCI16Instr(instrValue);
                             rd = fields[3];
-                            uimm = ((fields[4] & 0x03) << 7) | (fields[2] << 6) | (fields[4] & 0x1C);
+                            uimm = ((fields[4] & 0x03) << 6) | (fields[2] << 5) | (fields[4] & 0x1C);
                             // lw rd,offset[7:2](x2)
                             new_instr = (uimm << 20) | (0b0010 << 15) | (0b010 << 12) | (rd << 7) | RVISA::Opcode::LOAD;
                         } break;

--- a/src/processors/RISC-V/rv_uncompress.h
+++ b/src/processors/RISC-V/rv_uncompress.h
@@ -261,9 +261,9 @@ public:
                                 imm = 0xFF80 | imm;
                             }
                             // beq rs1 ′ , x0, offset[8:1]
-                            new_instr = ((((imm & 0x8000) >> 9) | ((imm & 0x3F00) >> 8)) << 25) | (0b00 << 20) |
+                            new_instr = ((((imm & 0x0800) >> 5) | ((imm & 0x03F0) >> 4)) << 25) | (0b00 << 20) |
                                         (rs1 << 15) | (0b000 << 12) |
-                                        ((((imm & 0x000F) << 1) | ((imm & 0x4000) >> 14)) << 7) | RVISA::Opcode::BRANCH;
+                                        ((((imm & 0x000F) << 1) | ((imm & 0x0400) >> 10)) << 7) | RVISA::Opcode::BRANCH;
                         } break;
                         case 0b111: {  // c.bnez
                             const auto fields = RVInstrParser::getParser()->decodeCB16Instr(instrValue);
@@ -274,9 +274,9 @@ public:
                                 imm = 0xFF80 | imm;
                             }
                             // bne rs1 ′ , x0, offset[8:1]
-                            new_instr = ((((imm & 0x8000) >> 9) | ((imm & 0x3F00) >> 8)) << 25) | (0b00 << 20) |
+                            new_instr = ((((imm & 0x0800) >> 5) | ((imm & 0x03F0) >> 4)) << 25) | (0b00 << 20) |
                                         (rs1 << 15) | (0b001 << 12) |
-                                        ((((imm & 0x000F) << 1) | ((imm & 0x4000) >> 14)) << 7) | RVISA::Opcode::BRANCH;
+                                        ((((imm & 0x000F) << 1) | ((imm & 0x0400) >> 10)) << 7) | RVISA::Opcode::BRANCH;
                         } break;
                     }
                     break;

--- a/test/riscv-tests-c/rvc.s
+++ b/test/riscv-tests-c/rvc.s
@@ -248,8 +248,31 @@ test_42:
  li t2,582
  li gp,42
  bne t0,t2, fail 
-    
-    
+ 
+test_43:
+ li a5, 1     
+ c.bnez a5, 255    
+ bne zero,gp, test_44
+.zero 244
+ bne zero,gp, fail
+ nop
+ c.bnez a5, -255
+ 
+test_44:
+ li a5, 0      
+ c.beqz a5, 255    
+ bne zero,gp, test_45
+.zero 244
+ bne zero,gp, fail
+ nop
+ c.beqz a5, -255
+
+test_45:
+ li a5,0xabcd   
+ c.swsp a5, 252
+ c.lwsp a6, 252
+ bne a5,a6, fail 
+     
  bne zero,gp, pass
   
 


### PR DESCRIPTION
This PR fixes a bug in decoding the compressed instructions c.bnez and c.beqz.