### PR TITLE
Implement persisting UI states

### DIFF
--- a/src/console.cpp
+++ b/src/console.cpp
@@ -43,6 +43,10 @@ Console::Console(QWidget *parent) : QPlainTextEdit(parent) {
           });
 
   m_localEchoEnabled = RipesSettings::value(RIPES_SETTING_CONSOLEECHO).toBool();
+
+  // Retrieve and store saved window size and state
+   m_savedSize = RipesSettings::value(RIPES_SETTING_CONSOLESIZE).toSize();
+   m_savedState = static_cast<Qt::WindowStates>(RipesSettings::value(RIPES_SETTING_CONSOLESTATE).toInt());
 }
 
 void Console::putData(const QByteArray &bytes) {
@@ -109,7 +113,19 @@ void Console::keyPressEvent(QKeyEvent *e) {
         }
       }
     }
-  }
+    }
+}
+
+void Console::resizeEvent(QResizeEvent *event) {
+    QPlainTextEdit::resizeEvent(event);
+    m_savedSize = event->size();
+    m_savedState = windowState();
+}
+
+void Console::moveEvent(QMoveEvent *event) {
+    QPlainTextEdit::moveEvent(event);
+    m_savedSize = event->pos();
+    m_savedState = windowState();
 }
 
 } // namespace Ripes

--- a/src/console.h
+++ b/src/console.h
@@ -20,6 +20,8 @@ public:
 
 protected:
   void keyPressEvent(QKeyEvent *e) override;
+  void resizeEvent(QResizeEvent *) override;
+  void moveEvent(QMoveEvent *) override;
 
 private:
   void backspace();
@@ -27,6 +29,10 @@ private:
   bool m_localEchoEnabled = false;
   QFont m_font;
   QString m_buffer;
+
+  // window size & state.
+  QVariant m_savedSize;
+  Qt::WindowStates m_savedState;
 };
 
 } // namespace Ripes

--- a/src/ripessettings.h
+++ b/src/ripessettings.h
@@ -21,6 +21,8 @@ namespace Ripes {
 #define RIPES_SETTING_CONSOLEFONT ("console_font")
 #define RIPES_SETTING_INDENTAMT ("editor_indent")
 #define RIPES_SETTING_UIUPDATEPS ("ui_update_ps")
+#define RIPES_SETTING_CONSOLESIZE ("console/windowsize")
+#define RIPES_SETTING_CONSOLESTATE ("console/windowstate")
 
 #define RIPES_SETTING_ASSEMBLER_TEXTSTART ("text_start")
 #define RIPES_SETTING_ASSEMBLER_DATASTART ("data_start")


### PR DESCRIPTION
Fix: #293 

I have started the task, please let me know if I am going in the right direction. Just for my check the `moveEvent` doesn't have any size() function it has ``QPoint`` so to avoid the implications I set the`m_savedSize` type to ```QVariant``` would that be okay?