### PR TITLE
Add a dynamic ISA reference

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -11,6 +11,7 @@
 #include "registerwidget.h"
 #include "ripessettings.h"
 #include "savedialog.h"
+#include "sliderulestab.h"
 #include "settingsdialog.h"
 #include "syscall/syscallviewer.h"
 #include "syscall/systemio.h"
@@ -90,12 +91,19 @@ MainWindow::MainWindow(QWidget *parent)
   m_stackedTabs->insertWidget(IOTabID, IOTab);
   m_tabWidgets[IOTabID] = {IOTab, IOToolbar};
 
+  auto *sliderulesToolbar = addToolBar("Sliderules");
+  sliderulesToolbar->setVisible(false);
+  auto *sliderulesTab = new SliderulesTab(sliderulesToolbar, this);
+  m_stackedTabs->insertWidget(SliderulesTabID, sliderulesTab);
+  m_tabWidgets[SliderulesTabID] = {sliderulesTab, sliderulesToolbar};
+
   // Setup tab bar
   m_ui->tabbar->addFancyTab(QIcon(":/icons/binary-code.svg"), "Editor");
   m_ui->tabbar->addFancyTab(QIcon(":/icons/cpu.svg"), "Processor");
   m_ui->tabbar->addFancyTab(QIcon(":/icons/server.svg"), "Cache");
   m_ui->tabbar->addFancyTab(QIcon(":/icons/ram-memory.svg"), "Memory");
   m_ui->tabbar->addFancyTab(QIcon(":/icons/led.svg"), "I/O");
+  m_ui->tabbar->addFancyTab(QIcon(":/icons/notepad.svg"), "Sliderules");
   connect(m_ui->tabbar, &FancyTabBar::activeIndexChanged, this,
           &MainWindow::tabChanged);
   connect(m_ui->tabbar, &FancyTabBar::activeIndexChanged, m_stackedTabs,

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -37,6 +37,7 @@ class MainWindow : public QMainWindow {
     CacheTabID,
     MemoryTabID,
     IOTabID,
+    SliderulesTabID,
     NTabsID
   };
 

--- a/src/processortab.cpp
+++ b/src/processortab.cpp
@@ -27,6 +27,82 @@
 
 namespace Ripes {
 
+
+static QString generateTooltipTable() {
+  // Create HTML table of instruction encoding for use in instruction tooltip
+  QString tooltipTable = "<table border=\"1\">"
+                         "<thead><tr>";
+  // Table header
+  for (int i = 0; i < 32; ++i) {
+    tooltipTable += "<th width=\"20\" align=\"center\">";
+    tooltipTable += QString::number(31 - i);
+    tooltipTable += "</th>";
+  }
+  tooltipTable += "</tr></thead>"
+                  "<tbody><tr>";
+
+  // add instruction
+  auto tdStart = "<td align=\"center\">";
+  auto tdStartRed = "<td bgcolor=\"#ea9999\" align=\"center\">";
+  auto tdStartLightRed = "<td bgcolor=\"#f4cccc\" align=\"center\">";
+  auto tdStartReg = "<td colspan=\"5\" bgcolor=\"#efefef\" align=\"center\">";
+  auto tdEnd = "</td>";
+  //  funct7
+  tooltipTable += tdStartRed;
+  tooltipTable += "-";
+  tooltipTable += tdEnd;
+  tooltipTable += tdStartRed;
+  tooltipTable += "0";
+  tooltipTable += tdEnd;
+  for (int i = 0; i < 5; ++i) {
+    tooltipTable += tdStartRed;
+    tooltipTable += "-";
+    tooltipTable += tdEnd;
+  }
+  //  rs2
+  tooltipTable += tdStartReg;
+  tooltipTable += "rs2";
+  tooltipTable += tdEnd;
+  //  rs1
+  tooltipTable += tdStartReg;
+  tooltipTable += "rs1";
+  tooltipTable += tdEnd;
+  //  funct3
+  for (int i = 0; i < 3; ++i) {
+    tooltipTable += tdStartRed;
+    tooltipTable += "0";
+    tooltipTable += tdEnd;
+  }
+  //  rd
+  tooltipTable += tdStartReg;
+  tooltipTable += "rd";
+  tooltipTable += tdEnd;
+  //  opcode
+  tooltipTable += tdStartLightRed;
+  tooltipTable += "0";
+  tooltipTable += tdEnd;
+  for (int i = 0; i < 2; ++i) {
+    tooltipTable += tdStartLightRed;
+    tooltipTable += "1";
+    tooltipTable += tdEnd;
+  }
+  for (int i = 0; i < 2; ++i) {
+    tooltipTable += tdStartLightRed;
+    tooltipTable += "0";
+    tooltipTable += tdEnd;
+  }
+  //  quadrant
+  for (int i = 0; i < 2; ++i) {
+    tooltipTable += tdStart;
+    tooltipTable += "1";
+    tooltipTable += tdEnd;
+  }
+
+  tooltipTable += "</tr></tbody>"
+                  "</table>";
+  return tooltipTable;
+}
+
 static QString convertToSIUnits(const double l_value, int precision = 2) {
   QString unit;
   double value;
@@ -491,6 +567,7 @@ void ProcessorTab::updateInstructionLabels() {
       instrLabel->clearForcedDefaultTextColor();
     }
     instrLabel->setText(instrString);
+    instrLabel->setToolTip(generateTooltipTable());
   }
 }
 

--- a/src/sliderulestab.cpp
+++ b/src/sliderulestab.cpp
@@ -1,0 +1,149 @@
+#include "sliderulestab.h"
+#include "ui_sliderulestab.h"
+
+namespace Ripes {
+
+QStringList HEADER_LABELS = { "Instr", "31", "30", "29", "28", "27", "26",
+                             "25", "24", "23", "22", "21", "20", "19", "18",
+                             "17", "16", "15", "14", "13", "12", "11", "10",
+                             "9", "8", "7", "6", "5", "4", "3", "2", "1", "0"};
+
+SliderulesTab::SliderulesTab(QToolBar *toolbar, QWidget *parent)
+    : RipesTab(toolbar, parent), m_ui(new Ui::SliderulesTab) {
+  m_ui->setupUi(this);
+
+  m_ui->tableWidget->setColumnWidth(0, 100);
+  m_ui->tableWidget->setHorizontalHeaderLabels(HEADER_LABELS);
+
+  auto *cellTemplate = new QTableWidgetItem("");
+  cellTemplate->setTextAlignment(Qt::AlignCenter);
+  auto *cellTemplateBold = cellTemplate->clone();
+  auto font = cellTemplateBold->font();
+  font.setBold(true);
+  cellTemplateBold->setFont(font);
+  auto *redItem = cellTemplateBold->clone();
+  redItem->setBackground(QBrush(QColor::fromRgb(224, 102, 102)));
+  auto *greenItem = cellTemplateBold->clone();
+  greenItem->setBackground(QBrush(QColor::fromRgb(147, 196, 125)));
+  auto *grayItem = cellTemplate->clone();
+  grayItem->setBackground(QBrush(QColor::fromRgb(239, 239, 239)));
+
+  auto *lightRedItem = cellTemplateBold->clone();
+  lightRedItem->setBackground(QBrush(QColor::fromRgb(234, 153, 153)));
+  auto *brightRedItem = cellTemplateBold->clone();
+  brightRedItem->setBackground(QBrush(QColor::fromRgb(244, 204, 204)));
+  auto *lightGreenItem = cellTemplateBold->clone();
+  lightGreenItem->setBackground(QBrush(QColor::fromRgb(182, 215, 168)));
+  auto *brightGreenItem = cellTemplateBold->clone();
+  brightGreenItem->setBackground(QBrush(QColor::fromRgb(217, 234, 211)));
+
+  auto *zeroLightRed = lightRedItem->clone();
+  zeroLightRed->setText("0");
+  auto *dashLightRed = lightRedItem->clone();
+  dashLightRed->setText("-");
+  auto *zeroBrightRed = brightRedItem->clone();
+  zeroBrightRed->setText("0");
+  auto *oneBrightRed = brightRedItem->clone();
+  oneBrightRed->setText("1");
+  auto *oneWhite = cellTemplate->clone();
+  oneWhite->setText("1");
+  auto *m1Green = greenItem->clone();
+  m1Green->setText("m1");
+  auto *m1ExtendedGreen = greenItem->clone();
+  m1ExtendedGreen->setText("- m1 -");
+  auto *imm1Green = greenItem->clone();
+  imm1Green->setText("imm1");
+  auto *zeroLightGreen = lightGreenItem->clone();
+  zeroLightGreen->setText("0");
+  auto *zeroBrightGreen = brightGreenItem->clone();
+  zeroBrightGreen->setText("0");
+  auto *oneBrightGreen = brightGreenItem->clone();
+  oneBrightGreen->setText("1");
+
+  // add
+  //  instruction
+  auto *add = redItem->clone();
+  add->setText("add");
+  m_ui->tableWidget->setItem(0, 0, add);
+  //  funct7
+  for (int i = 0; i < 7; ++i) {
+    QTableWidgetItem *item;
+    if (i == 1) {
+      item = zeroLightRed->clone();
+    } else {
+      item = dashLightRed->clone();
+    }
+    m_ui->tableWidget->setItem(0, i + 1, item);
+  }
+  //  rs2
+  auto *rs2 = grayItem->clone();
+  rs2->setText("rs2");
+  m_ui->tableWidget->setItem(0, 8, rs2);
+  m_ui->tableWidget->setSpan(0, 8, 1, 5);
+  //  rs1
+  auto *rs1 = grayItem->clone();
+  rs1->setText("rs1");
+  m_ui->tableWidget->setItem(0, 13, rs1);
+  m_ui->tableWidget->setSpan(0, 13, 1, 5);
+  //  funct3
+  for (int i = 0; i < 3; ++i) {
+    m_ui->tableWidget->setItem(0, i + 18, zeroLightRed->clone());
+  }
+  //  rd
+  auto *rd= grayItem->clone();
+  rd->setText("rd");
+  m_ui->tableWidget->setItem(0, 21, rd);
+  m_ui->tableWidget->setSpan(0, 21, 1, 5);
+  //  opcode
+  m_ui->tableWidget->setItem(0, 26, zeroBrightRed->clone());
+  m_ui->tableWidget->setItem(0, 27, oneBrightRed->clone());
+  m_ui->tableWidget->setItem(0, 28, oneBrightRed->clone());
+  m_ui->tableWidget->setItem(0, 29, zeroBrightRed->clone());
+  m_ui->tableWidget->setItem(0, 30, zeroBrightRed->clone());
+  //  quadrant
+  m_ui->tableWidget->setItem(0, 31, oneWhite->clone());
+  m_ui->tableWidget->setItem(0, 32, oneWhite->clone());
+
+  // addi
+  //  instruction
+  auto *addi = greenItem->clone();
+  addi->setText("addi");
+  m_ui->tableWidget->setItem(1, 0, addi);
+  m_ui->tableWidget->setSpan(1, 0, 2, 1);
+  //  imm
+  m_ui->tableWidget->setItem(1, 1, m1Green->clone());
+  m_ui->tableWidget->setItem(1, 2, imm1Green->clone());
+  m_ui->tableWidget->setSpan(1, 2, 1, 11);
+  //  rs
+  auto *rs = grayItem->clone();
+  rs->setText("rs");
+  m_ui->tableWidget->setItem(1, 13, rs);
+  m_ui->tableWidget->setSpan(1, 13, 1, 5);
+  //  funct3
+  for (int i = 0; i < 3; ++i) {
+    m_ui->tableWidget->setItem(1, i + 18, zeroLightGreen->clone());
+  }
+  //  rd
+  m_ui->tableWidget->setItem(1, 21, rd->clone());
+  m_ui->tableWidget->setSpan(1, 21, 1, 5);
+  //  opcode
+  m_ui->tableWidget->setItem(1, 26, zeroBrightGreen->clone());
+  m_ui->tableWidget->setItem(1, 27, zeroBrightGreen->clone());
+  m_ui->tableWidget->setItem(1, 28, oneBrightGreen->clone());
+  m_ui->tableWidget->setItem(1, 29, zeroBrightGreen->clone());
+  m_ui->tableWidget->setItem(1, 30, zeroBrightGreen->clone());
+  //  quadrant
+  m_ui->tableWidget->setItem(1, 31, oneWhite->clone());
+  m_ui->tableWidget->setItem(1, 32, oneWhite->clone());
+  // addi immediate
+  m_ui->tableWidget->setItem(2, 1, m1ExtendedGreen->clone());
+  m_ui->tableWidget->setSpan(2, 1, 1, 21);
+  m_ui->tableWidget->setItem(2, 22, imm1Green->clone());
+  m_ui->tableWidget->setSpan(2, 22, 1, 11);
+}
+
+SliderulesTab::~SliderulesTab() {
+  delete m_ui;
+}
+
+}

--- a/src/sliderulestab.h
+++ b/src/sliderulestab.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "ripestab.h"
+
+namespace Ripes {
+
+namespace Ui {
+class SliderulesTab;
+}
+
+class SliderulesTab : public RipesTab {
+  Q_OBJECT
+
+public:
+  SliderulesTab(QToolBar *toolbar, QWidget *parent = nullptr);
+  ~SliderulesTab() override;
+
+private:
+  Ui::SliderulesTab *m_ui = nullptr;
+};
+
+}

--- a/src/sliderulestab.ui
+++ b/src/sliderulestab.ui
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Ripes::SliderulesTab</class>
+ <widget class="QWidget" name="Ripes::SliderulesTab">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>1057</width>
+    <height>384</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="1" column="0">
+    <widget class="QTableWidget" name="tableWidget">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="rowCount">
+      <number>3</number>
+     </property>
+     <property name="columnCount">
+      <number>33</number>
+     </property>
+     <attribute name="horizontalHeaderMinimumSectionSize">
+      <number>30</number>
+     </attribute>
+     <attribute name="horizontalHeaderDefaultSectionSize">
+      <number>30</number>
+     </attribute>
+     <attribute name="verticalHeaderVisible">
+      <bool>false</bool>
+     </attribute>
+     <row/>
+     <row/>
+     <row/>
+     <column/>
+     <column/>
+     <column/>
+     <column/>
+     <column/>
+     <column/>
+     <column/>
+     <column/>
+     <column/>
+     <column/>
+     <column/>
+     <column/>
+     <column/>
+     <column/>
+     <column/>
+     <column/>
+     <column/>
+     <column/>
+     <column/>
+     <column/>
+     <column/>
+     <column/>
+     <column/>
+     <column/>
+     <column/>
+     <column/>
+     <column/>
+     <column/>
+     <column/>
+     <column/>
+     <column/>
+     <column/>
+     <column/>
+     <item row="0" column="0">
+      <property name="text">
+       <string/>
+      </property>
+     </item>
+     <item row="0" column="1">
+      <property name="text">
+       <string/>
+      </property>
+     </item>
+     <item row="1" column="0">
+      <property name="text">
+       <string/>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>75</height>
+      </size>
+     </property>
+     <property name="title">
+      <string>Filter</string>
+     </property>
+     <widget class="QWidget" name="gridLayoutWidget">
+      <property name="geometry">
+       <rect>
+        <x>20</x>
+        <y>20</y>
+        <width>261</width>
+        <height>51</height>
+       </rect>
+      </property>
+      <layout class="QGridLayout" name="gridLayout_2">
+       <item row="0" column="0">
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>Instruction Name</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QLineEdit" name="lineEdit">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
Draft branch for #297.

Here's my plan on how to implement this feature:

- [x] Static sliderules tab UI with instruction encodings for 2 instructions
- [x] Tooltip UI for 2 instructions at a single location
- [ ] Tooltip UI for 2 instructions at multiple locations
- [ ] Dynamic sliderules tab UI with instruction encodings for 2 instructions per instruction type
- [ ] Dynamic tooltip UI with instruction encodings for 2 instructions per instruction type
- [ ] Fill out instruction details so that all instructions are included in the UI

Added a new tab for an ISA reference table.

![SliderulesDemo0](https://github.com/mortbopet/Ripes/assets/76848730/fc29c6f1-b0d3-4fc2-bf96-36c8ef77ed47)
