### PR TITLE
Update clang-format PR check to not throw errors when files are removed

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -16,7 +16,7 @@ jobs:
     - name: clang-format
       run: |
         # Run clang-format
-        CHANGED_FILES=`git diff --name-only -r HEAD~ | grep -E '.(c|cpp|h|hpp)$' | xargs`
+        CHANGED_FILES=`git diff --name-only -r HEAD~ --diff-filter=d | grep -E '.(c|cpp|h|hpp)$' | xargs`
         echo "Changed files: $CHANGED_FILES"
         [ -z "$CHANGED_FILES" ] && exit 0
         clang-format -i $CHANGED_FILES


### PR DESCRIPTION
This change filters out deleted files from being formatted in pull request checks.