### PR TITLE
Fix O_CREAT flag in open syscall

### DIFF
--- a/src/syscall/systemio.h
+++ b/src/syscall/systemio.h
@@ -169,7 +169,7 @@ private:
       auto &file = files[fd];
       file.open(qtOpenFlags);
 
-      if (!file.exists() && flags & O_CREAT) {
+      if (!file.exists() && !(flags & O_CREAT)) {
         throw std::runtime_error("Could not create file");
       }
 


### PR DESCRIPTION
In the open syscall, a new file would be created if the opened file didn't exist and the `O_CREAT` flag was NOT set.

This has been fixed to create a new file only if the `O_CREAT` flag IS set. This matches the original Unix flag.