### PR TITLE
Add missing virtual destructors to abstract classes

### DIFF
--- a/src/isa/isainfo.h
+++ b/src/isa/isainfo.h
@@ -24,6 +24,7 @@ struct RegisterFileName {
 
 /// An interface into a register file.
 struct RegFileInfoInterface {
+  virtual ~RegFileInfoInterface(){};
   /// Returns this register file's type.
   virtual std::string_view regFileName() const = 0;
   /// Returns this register file's description.

--- a/src/isa/pseudoinstruction.h
+++ b/src/isa/pseudoinstruction.h
@@ -9,6 +9,7 @@
 namespace Ripes {
 
 struct PseudoInstructionBase {
+  virtual ~PseudoInstructionBase() {}
   virtual Result<std::vector<LineTokens>> expand(const TokenizedSrcLine &line,
                                                  SymbolMap &symbols) const = 0;
   virtual QString name() const = 0;


### PR DESCRIPTION
Virtual destructors that were previously missing have been added to the following abstract classes:

* `RegFileInfoInterface`
* `PseudoInstructionBase`

This fixes #331.