### PR TITLE
Fix issue #258

### DIFF
--- a/src/isa/rv_i_ext.h
+++ b/src/isa/rv_i_ext.h
@@ -271,7 +271,7 @@ struct Ecall : public Instr<Ecall, Funct12::ECALL> {
 
 namespace TypeU {
 
-/// A RISC-V immediate field with an input width of 32 bits.
+/// A RISC-V immediate field with an input width of 20 bits.
 /// Used in U-Type instructions.
 ///
 /// It is defined as:
@@ -280,7 +280,7 @@ namespace TypeU {
 constexpr static unsigned VALID_INDEX = 1;
 template <unsigned index, SymbolType symbolType>
 struct ImmU
-    : public ImmSym<index, 32, Repr::Hex, ImmPart<0, 12, 31>, symbolType> {
+    : public ImmSym<index, 20, Repr::Hex, ImmPart<0, 12, 31>, symbolType> {
   static_assert(index == VALID_INDEX, "Invalid token index");
 };
 


### PR DESCRIPTION

## Description

As the issue desciption said, in the latest Ripes, most of the I-type instructions will check whether the given immediate part can fit in the instruction limitation.

For example, the `addi` instruction will ensure the given immediate is less than 13 bits, as the following image shows:

![image](https://github.com/mortbopet/Ripes/assets/57722945/852efca3-b1ed-4ee9-a291-2656a3bbaa84)

However, the `lui` instruction's immediate part should only accept an immediate value that could fit in 20 bits, but current version doesn't handle this limitation correctly, as shown in the above image. 

## Tracing

To find the problem, I use `std::cout` to dump the `width` in the `checkFitsInWidth` function, which is for checking the immediate range: 

```cpp
static Result<> checkFitsInWidth(Reg_T_S value, const Location &sourceLine,
                                  ImmConvInfo &convInfo,
                                  QString token = QString()) {

  std::cout << __PRETTY_FUNCTION__ << std::endl
            << "check token '" << token.toStdString() << "' (expected width=" << width
            << ") at #" << sourceLine.sourceLine() << std::endl;

  ...
```

Then, rebuild the Ripes and test it with the following codes:

```asm
main:
    addi x1, x1, 0x123455
    lui x1, 0x12345678
```

And found that the `width` of `lui` instruction is misconfigured as 32, instead of 20:

```cpp

static Ripes::Result<> Ripes::ImmBase<tokenIndex, width, repr, ImmParts, symbolType, transformer>::checkFitsInWidth(Ripes::ImmBase<tokenIndex, width, repr, ImmParts, symbolType, transformer>::Reg_T_S, const Ripes::Location&, Ripes::ImmConvInfo&, QString) [with unsigned int tokenIndex = 2; unsigned int width = 12; Ripes::Repr repr = Ripes::Repr::Signed; ImmParts = Ripes::ImmPartBase<0, Ripes::BitRange<20, 31, 32> >; Ripes::SymbolType symbolType = Ripes::SymbolType::None; Ripes::Reg_T (* transformer)(Ripes::Reg_T) = Ripes::defaultTransformer; Ripes::ImmBase<tokenIndex, width, repr, ImmParts, symbolType, transformer>::Reg_T_S = long int]
check token '0x123455' (expected width=12) at #1
static Ripes::Result<> Ripes::ImmBase<tokenIndex, width, repr, ImmParts, symbolType, transformer>::checkFitsInWidth(Ripes::ImmBase<tokenIndex, width, repr, ImmParts, symbolType, transformer>::Reg_T_S, const Ripes::Location&, Ripes::ImmConvInfo&, QString) [with unsigned int tokenIndex = 1; unsigned int width = 32; Ripes::Repr repr = Ripes::Repr::Hex; ImmParts = Ripes::ImmPartBase<0, Ripes::BitRange<12, 31, 32> >; Ripes::SymbolType symbolType = Ripes::SymbolType::None; Ripes::Reg_T (* transformer)(Ripes::Reg_T) = Ripes::defaultTransformer; Ripes::ImmBase<tokenIndex, width, repr, ImmParts, symbolType, transformer>::Reg_T_S = long int]
check token '0x12345678' (expected width=32) at #2
```

And this is origin from the the U-type instruction implementation, we can see that the `width` is configured as 32:

```cpp
/// A RISC-V immediate field with an input width of 32 bits.
/// Used in U-Type instructions.
///
/// It is defined as:
///  - Imm[31:12] = Inst[31:12]
///  - Imm[11:0]  = 0
constexpr static unsigned VALID_INDEX = 1;
template <unsigned index, SymbolType symbolType>
struct ImmU
    : public ImmSym<index, 32, Repr::Hex, ImmPart<0, 12, 31>, symbolType> {
  static_assert(index == VALID_INDEX, "Invalid token index");
};

/// A U-Type RISC-V instruction
template <typename InstrImpl, RVISA::OpcodeID opcodeID,
          SymbolType symbolType = SymbolType::None>
class Instr : public RV_Instruction<InstrImpl> {
  template <unsigned index>
  using Imm = ImmU<index, symbolType>;

public:
  struct Opcode : public OpcodeSet<OpPartOpcode<opcodeID>> {};
  struct Fields : public FieldSet<RegRd, Imm> {};
};

struct Auipc
    : public Instr<Auipc, RVISA::OpcodeID::AUIPC, SymbolType::Absolute> {
  constexpr static std::string_view NAME = "auipc";
};

struct Lui : public Instr<Lui, RVISA::OpcodeID::LUI> {
  constexpr static std::string_view NAME = "lui";
};

} // namespace TypeU
```

## Solve

By changing the width to 20, the bit range checking now works as expected, on the `lui` and `auipc` :

![image](https://github.com/mortbopet/Ripes/assets/57722945/f867b9f7-a77c-40a7-ba9a-e9e4648de655)

## Testing

Currently I only use the provided testing utility for checking my changes didn't break it:

```bash
/ripes/build/test$ ./tst_assembler && ./tst_expreval && ./tst_riscv

...

Totals: 10 passed, 0 failed, 0 skipped, 0 blacklisted, 9676ms
********* Finished testing of tst_RISCV *********
```

However, since I'm not that familiar with C++, I'm not sure whether I understood the bit range checking process correctly. If there is any problem in my changes, please me know.
