### PR TITLE
Fix Issue: WASM, Reading console input does not work

### DIFF
--- a/src/console.cpp
+++ b/src/console.cpp
@@ -77,37 +77,34 @@ void Console::keyPressEvent(QKeyEvent *e) {
   case Qt::Key_Down:
     QPlainTextEdit::keyPressEvent(e);
     break;
+
+  case Qt::Key_Return:
+  case Qt::Key_Enter:
+    // Return is interpreted as \n instead of the default \r (\n)
+    m_buffer += "\n";
+
+    // Flush buffer to output
+    emit sendData(m_buffer.toLocal8Bit());
+    m_buffer.clear();
+
+    if (m_localEchoEnabled)
+      putData("\r");
+    break;
+
+  case Qt::Key_Backspace:
+    if (!m_buffer.isEmpty()) {
+      // Remove the last character from the buffer
+      m_buffer.chop(1);
+      if (m_localEchoEnabled)
+        backspace();
+    }
+    break;
+
   default:
     if (!e->text().isEmpty()) {
-      bool backspacedBuffer = false;
-      const QString text = e->text();
-      // Buffer managing
-      if (e->key() == Qt::Key_Return || e->key() == Qt::Key_Enter) {
-        // Return is interpreted as \n instead of the default \r
-        m_buffer += "\n";
-
-        // Flush buffer to output
-        emit sendData(m_buffer.toLocal8Bit());
-        m_buffer.clear();
-      } else if (e->key() == Qt::Key_Backspace) {
-        if (!m_buffer.isEmpty()) {
-          m_buffer.chop(1);
-          backspacedBuffer = true;
-        }
-      } else {
-        m_buffer += text;
-      }
-
-      // Console echoing
-      if (m_localEchoEnabled) {
-        if (e->key() == Qt::Key_Backspace) {
-          if (backspacedBuffer) {
-            backspace();
-          }
-        } else {
-          putData(text.toUtf8());
-        }
-      }
+      m_buffer += e->text();
+      if (m_localEchoEnabled)
+        putData(e->text().toUtf8());
     }
   }
 }


### PR DESCRIPTION
In the current  WebAssembly (WASM) version of Ripes there's an issue preventing input reading from the console. This because pressing `Enter` does not return control to the processor, as stated in issue #304.

The problems stems from the behaviour of the `Console::keyPressEvent(QKeyEvent *e)` method, which requires a `QKeyEvent` parameter, that appears to behave differently in the binary executable compared to the WASM version. 
In the binary executable, when pressing Enter or Return, the `QKeyEvent` associated with the keys `Qt::Key_Return` or `Qt::Key_Enter` has a non empty text field (`e->text()`). However, in the WASM version that field is empty and therefore the check `if (!e->text().isEmpty())` always returns false when pressing Enter, resulting in the already reported error.
The same happens with the Backspace Key.

### Proposed fix

I propose altering the handling of these events: rather than mandating a non-empty text field in the `QKeyEvent`, I suggest to verify only the key associated with each command. Text inspection should only occur for the events where the key is not checked.

As stated in the [Qt documentation of the QKeyEvent Class of `key()`](https://doc.qt.io/qt-6/qkeyevent.html#key):
> Returns the code of the key that was pressed or released.
> See [Qt::Key](https://doc.qt.io/qt-6/qt.html#Key-enum) for the list of keyboard codes. These codes are independent of the underlying window system. 

The `key()` of an event is independent from the underlying system while the `text()` may not.

In the modified code, all types of `QKeyEvent` are processed using the same switch-case structure, as currently happens for the directional keys. When a key event is triggered, the program checks if the key corresponds to any of the arrow keys, the _Enter_ key, the _Return_ key or the _Backspace_ key.
If the key does not match any of these, the event is handled as it used to: first, it checks that the content of the key event is not empty, ensuring that modifier keys such as _Shift_, _Control_, or _Alt_ are not considered. Then, it adds the content of the event to the buffer and calls the `putData()` method.