### PR TITLE
Fix: change '--mode sh' to '--mode cli' in help text

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -18,7 +18,7 @@ void initParser(QCommandLineParser &parser, Ripes::CLIModeOptions &options) {
       "\n"
       "program on an arbitrary processor model and subsequent reporting of \n"
       "execution telemetry.\nCommand line mode is enabled when the '--mode "
-      "sh' argument is provided.";
+      "cli' argument is provided.";
 
   helpText.prepend("Ripes command line interface.\n");
   parser.setApplicationDescription(helpText);


### PR DESCRIPTION
Ditto. Fixes  #375. 

P.S.: Please notice that the failures in the docker image and code format tests are due to the tests having rot away and are unrelated with the PR itself.