### PR TITLE
Fix Deprecation Error

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -29,7 +29,7 @@ jobs:
         echo "Clang-format found no formatting problems"
         exit 0
     - name: Upload clang-format patch
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       if: ${{ failure() }}
       # Unfortunately, artifact uploads are always zips :(
       with:

--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -71,7 +71,7 @@ jobs:
         ./linuxdeployqt-continuous-x86_64.AppImage --appimage-extract-and-run appdir/usr/share/applications/*.desktop \
           -appimage -verbose=2 -extra-plugins=iconengines
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.build-type }}_executable
         path: Ripes*.AppImage*

--- a/.github/workflows/mac-release.yml
+++ b/.github/workflows/mac-release.yml
@@ -59,7 +59,7 @@ jobs:
         sudo mv Ripes.app ${APPNAME}.app
         sudo zip -r ${APPNAME}.zip ${APPNAME}.app/
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.build-type }}_executable
         path: ${{ env.APPNAME }}.zip

--- a/.github/workflows/wasm-release.yml
+++ b/.github/workflows/wasm-release.yml
@@ -91,7 +91,7 @@ jobs:
           .
         make -j $(nproc)
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.build-type }}_wasm
         path: |

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -54,7 +54,7 @@ jobs:
           --no-compiler-runtime --no-opengl-sw --no-translations Ripes.exe
         7z a -r ../${APPNAME} *
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.build-type }}_executable
         path: ${{ env.APPNAME }}


### PR DESCRIPTION
Fix [deprecated version](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/) of `actions/upload-artifact` in workflows. 

Fixes: #380.