### PR TITLE
Implement System Input Handling for CLI Execution

### DIFF
--- a/src/cli/clirunner.cpp
+++ b/src/cli/clirunner.cpp
@@ -11,8 +11,13 @@
 
 namespace Ripes {
 
-// An extended QVariant-to-string convertion method which handles a few special
-// cases.
+/**
+ * An extended QVariant-to-string convertion method which handles a special
+ * cases such as QVariantMap and QStringList.
+ * 
+ * @param v The QVariant to convert to a string.
+ * @returns A string representation of the QVariant.
+ */
 static QString qVariantToString(QVariant &v) {
   QString def = v.toString();
   if (!def.isEmpty())
@@ -34,6 +39,14 @@ static QString qVariantToString(QVariant &v) {
   return def;
 }
 
+/**
+ * Constructor for the CLIRunner class.
+ * Initializes the CLI runner for Ripes. 
+ * It configures the environment based on the provided options and prepares the 
+ * SystemIO streams for input and output redirection.
+ * 
+ * @param options A struct containing the CLI options for Ripes.
+ */
 CLIRunner::CLIRunner(const CLIModeOptions &options)
     : QObject(), m_options(options) {
   info("Ripes CLI mode", false, true);
@@ -46,9 +59,18 @@ CLIRunner::CLIRunner(const CLIModeOptions &options)
     std::flush(std::cout);
   });
 
-  // TODO: how to handle system input?
+  // Handle systemIO input in stdin
+  SystemIO::setCLIInput();
 }
 
+/**
+ * Main execution method for the CLI runner.
+ * Runs the CLI process in three phases: process input, run model, and post-run.
+ * Checks after each phase that the execution was successful, and returns 1 if an
+ * error occurs during any phase.
+ * 
+ * @return 0 on success, or 1 if an error occurs during any phase.
+ */
 int CLIRunner::run() {
   if (processInput())
     return 1;
@@ -62,6 +84,13 @@ int CLIRunner::run() {
   return 0;
 }
 
+/**
+ * Processes the input file based on the file source type in the provided CLI options.
+ * The method prepares the program for the execution by assembling, compiling, 
+ * or loading the input file (based on the source type).
+ * 
+ * @return 0 on success, or 1 if an error occurs during input file processing.
+ */
 int CLIRunner::processInput() {
   info("Processing input file", false, true);
 
@@ -157,11 +186,15 @@ int CLIRunner::processInput() {
   return 0;
 }
 
+/**
+ * Runs the processor model for the loaded program until the program is 
+ * finished (so ProcessorHandler::runFinished signal is emitted)
+ * 
+ * @return 0 on success, or 1 if an error occurs during model execution.
+ */
 int CLIRunner::runModel() {
   info("Running model", false, true);
 
-  // Wait until receiving ProcessorHandler::runFinished signal
-  // before proceeding.
   QEventLoop loop;
   QObject::connect(ProcessorHandler::get(), &ProcessorHandler::runFinished,
                    &loop, &QEventLoop::quit);
@@ -212,6 +245,13 @@ int CLIRunner::runModel() {
   return 0;
 }
 
+/**
+ * Handles post-execution tasks. 
+ * Open output file (if specified) or defaults to stdout and prints telemetry 
+ * data in either JSON or unstructured format.
+ * 
+ * @return 0 on success, or 1 if an error occurs during post run tasks.
+ */
 int CLIRunner::postRun() {
   info("Post-run", false, true);
 
@@ -256,6 +296,15 @@ int CLIRunner::postRun() {
   return 0;
 }
 
+/**
+ * Outputs an informational message to the standard output.
+ * For formatting purposes the message can include a header or a specified prefix.
+ * 
+ * @param msg The QString message to print.
+ * @param alwaysPrint If true, the message is printed regardless if the verbose option is disabled.
+ * @param header If true, the message is surrounded by a decorative header.
+ * @param prefix The prefix for the message, added only if "header" is false.
+ */
 void CLIRunner::info(QString msg, bool alwaysPrint, bool header,
                      const QString &prefix) {
 
@@ -276,6 +325,11 @@ void CLIRunner::info(QString msg, bool alwaysPrint, bool header,
   }
 }
 
+/**
+ * Prints an error message to stdout with an "ERROR" prefix.
+ * 
+ * @param msg The error message to print.
+ */
 void CLIRunner::error(const QString &msg) { info(msg, true, false, "ERROR"); }
 
 } // namespace Ripes

--- a/src/syscall/systemio.h
+++ b/src/syscall/systemio.h
@@ -371,7 +371,7 @@ public:
           postToGUIThread([=] { SystemIOStatusManager::clearStatus(); });
           return -1;
         }
-        auto readData = InputStream.read(lengthRequested).toUtf8();
+        auto readData = InputStream.read(1).toUtf8();
         myBuffer.append(readData);
         lengthRequested -= readData.length();
 
@@ -435,6 +435,17 @@ public:
     return lengthRequested;
 
   } // end writeToFile
+
+  
+  /**
+   * Redirects the stream associated with STDIN to the standard input (stdin).
+   * The method ensures that the STDIN stream is reset (erasing the existing mapping) 
+   * and explicitly maps it to the standard input stream (stdin).
+   */
+  static void setCLIInput(){
+    FileIOData::streams.erase(STDIN);
+    FileIOData::streams.emplace(STDIN, stdin);
+  }
 
   /**
    * Close the file with specified file descriptor


### PR DESCRIPTION
This commit implements a solution to handle system input within the Command-Line Interface (CLI), as in _Issue #353_.

Implemented changes:
- A new method, `SystemIO::setCLIInput(),` was added in the `systemio.h` file that sets the input stream to `STDIN`. This method is used only by the CLI, which doesn't support multi-thread execution and thus cannot rely on the same input handling methods as the GUI. The GUI has a dedicated thread for reading console input, while other threads manage the rest of the program.
- The `readFromFile()` method was updated to handle `STDIN` input differently. When `fd == STDIN`, it now reads one byte at a time using `InputStream.read(1)`. This continues until the specified number of bytes (`lengthRequested`) is reached or a newline (`'\n'`) character is encountered.
 
This change ensures that both the GUI and CLI can correctly handle `STDIN` input. Without reading one byte at a time, the CLI could not properly process inputs of a size different from the requested length, since there isn't a function like `putStdInData(const QByteArray &data)` in the CLI that pushes data into the `stdin` buffer object.
https://github.com/mortbopet/Ripes/blob/290c0e6be1bc280f9bdea8a74fe3e4c40145f025/src/syscall/systemio.h#L458-L463
For the GUI, STDIN is handled through the `QTextStream` object, which is linked in the `ConsoleWidget`:
https://github.com/mortbopet/Ripes/blob/290c0e6be1bc280f9bdea8a74fe3e4c40145f025/src/consolewidget.cpp#L23-L25

To integrate the new input handling in the CLI, a call to `SystemIO::setCLIInput()` is added in the `CLIRunner` constructor to set the input stream to `STDIN`:
```C++
CLIRunner::CLIRunner(const CLIModeOptions &options)
    : QObject(), m_options(options) {
  // to handle system input
  SystemIO::setCLIInput();
}
```

With these changes the `STDIN` input can be handled in both Ripes mode (GUI and CLI).
