### PR TITLE
Fix Issue: Division by zero crash in assembler constant expressions

### DIFF
--- a/src/assembler/expreval.cpp
+++ b/src/assembler/expreval.cpp
@@ -240,7 +240,13 @@ VIntS evaluate(const std::shared_ptr<Expr> &expr,
   }
   FiExpr;
   IfExpr(Div, v) {
-    return evaluate(v->lhs, variables) / evaluate(v->rhs, variables);
+    auto rhs_value = evaluate(v->rhs, variables);
+    if (rhs_value == 0) {
+      throw std::runtime_error(
+          "Division by zero error in expression evaluation.");
+    }
+
+    return evaluate(v->lhs, variables) / rhs_value;
   }
   FiExpr;
   IfExpr(Mul, v) {
@@ -252,7 +258,13 @@ VIntS evaluate(const std::shared_ptr<Expr> &expr,
   }
   FiExpr;
   IfExpr(Mod, v) {
-    return evaluate(v->lhs, variables) % evaluate(v->rhs, variables);
+    auto rhs_value = evaluate(v->rhs, variables);
+    if (rhs_value == 0) {
+      throw std::runtime_error(
+          "Modulo by zero error in expression evaluation.");
+    }
+
+    return evaluate(v->lhs, variables) % rhs_value;
   }
   FiExpr;
   IfExpr(And, v) {


### PR DESCRIPTION
Added checks in the expression evaluation (`evaluate`) method of `expreval.cpp` for division (`/`) and modulo (`%`) operations to prevent zero as a divisor.
Checks are performed by calculating and evaluating the _right-hand side value_ (`rhs_value`) of the binary operation. 
Used `std::runtime_error` to handle the case of division by zero so that the error is shown to the user directly in the written code in the text editor.

This fixes issue #347.