### PR TITLE
Accept labels that start with a dot.

### DIFF
--- a/src/assembler/assemblerbase.cpp
+++ b/src/assembler/assemblerbase.cpp
@@ -184,7 +184,7 @@ AssemblerBase::splitDirectivesFromLine(const Location &location,
       if (directivesStillAllowed) {
         directives.push_back(token);
       } else {
-        return {Error(location, QStringLiteral("Stray '.' in line"))};
+        remainingTokens.push_back(token); // may be a label
       }
     } else {
       remainingTokens.push_back(token);


### PR DESCRIPTION
Ripes assembler gives an error for any identifier that starts with a dot. However, such syntax seems valid and is in fact routinely used by GCC. 
This patch changes this, making copying and pasting from Compiler Explorer more straightforward.