### PR TITLE
Allow to set associativities of caches that are not power of 2.

### DIFF
--- a/src/cachesim/cacheconfigwidget.cpp
+++ b/src/cachesim/cacheconfigwidget.cpp
@@ -32,7 +32,7 @@ void CacheConfigWidget::setCache(const std::shared_ptr<CacheSim> &cache) {
   setupEnumCombobox(m_ui->wrHit, s_cacheWritePolicyStrings);
   setupEnumCombobox(m_ui->wrMiss, s_cacheWriteAllocateStrings);
 
-  m_ui->ways->setValue(m_cache->getWaysBits());
+  m_ui->ways->setValue(m_cache->getWays());
   m_ui->lines->setValue(m_cache->getLineBits());
   m_ui->blocks->setValue(m_cache->getBlockBits());
 
@@ -153,7 +153,7 @@ void CacheConfigWidget::handleConfigurationChanged() {
   std::for_each(m_configItems.begin(), m_configItems.end(),
                 [](QObject *o) { o->blockSignals(true); });
 
-  m_ui->ways->setValue(m_cache->getWaysBits());
+  m_ui->ways->setValue(m_cache->getWays());
   m_ui->lines->setValue(m_cache->getLineBits());
   m_ui->blocks->setValue(m_cache->getBlockBits());
   setEnumIndex(m_ui->wrHit, m_cache->getWritePolicy());

--- a/src/cachesim/cacheconfigwidget.ui
+++ b/src/cachesim/cacheconfigwidget.ui
@@ -142,7 +142,7 @@
             <item row="5" column="0">
              <widget class="QLabel" name="label_2">
               <property name="text">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;2&lt;span style=&quot; vertical-align:super;&quot;&gt;N&lt;/span&gt; Ways:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;Ways:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
              </widget>
             </item>

--- a/src/cachesim/cachegraphic.cpp
+++ b/src/cachesim/cachegraphic.cpp
@@ -107,7 +107,7 @@ void CacheGraphic::updateLineReplFields(unsigned lineIdx) {
     // If LRU was just initialized, the actual (software) LRU value may be very
     // large. Mask to the number of actual LRU bits.
     unsigned lruVal = cacheLine->at(way.first).lru;
-    lruVal &= vsrtl::generateBitmask(m_cache.getWaysBits());
+    lruVal = std::min(static_cast<unsigned>(m_cache.getWays() - 1), lruVal);
     const QString lruText = QString::number(lruVal);
     way.second.lru->setText(lruText);
 

--- a/src/cachesim/cachesim.cpp
+++ b/src/cachesim/cachesim.cpp
@@ -90,7 +90,7 @@ CacheSim::CacheSize CacheSim::getCacheSize() const {
 
   if (m_replPolicy == ReplPolicy::LRU) {
     // LRU bits
-    componentBits = getWaysBits() * entries;
+    componentBits = vsrtl::ceillog2(getWays()) * entries;
     size.components.push_back("LRU bits: " + QString::number(componentBits));
     size.bits += componentBits;
   }

--- a/src/cachesim/cachesim.h
+++ b/src/cachesim/cachesim.h
@@ -187,14 +187,13 @@ public:
   AInt buildAddress(unsigned tag, unsigned lineIdx, unsigned blockIdx) const;
 
   int getBlockBits() const { return m_blocks; }
-  int getWaysBits() const { return m_ways; }
   int getLineBits() const { return m_lines; }
   int getTagBits() const {
     return 32 - 2 /*byte offset*/ - getBlockBits() - getLineBits();
   }
 
   int getBlocks() const { return static_cast<int>(std::pow(2, m_blocks)); }
-  int getWays() const { return static_cast<int>(std::pow(2, m_ways)); }
+  int getWays() const { return m_ways; }
   int getLines() const { return static_cast<int>(std::pow(2, m_lines)); }
   unsigned getBlockMask() const { return m_blockMask; }
   unsigned getTagMask() const { return m_tagMask; }
@@ -277,7 +276,7 @@ private:
 
   int m_blocks = 2;           // Some power of 2
   int m_lines = 5;            // Some power of 2
-  int m_ways = 0;             // Some power of 2
+  int m_ways = 1;
   unsigned m_byteOffset = -1; // # of bits to represent the # of bytes in a word
   unsigned m_wordBits = -1;
 


### PR DESCRIPTION
Ripes currently restricts the associativity of caches to powers of two. However, there is no technical reason to do so in hardware and there are caches in the real world whose associativity is not a power of two (6 and 12-way caches are common, and there are examples of 11-way caches (e.g.: https://en.wikichip.org/wiki/intel/microarchitectures/skylake_(server))).

This patch removes this restriction.