### PR TITLE
Bump minimum ubuntu version to 22.04

### DIFF
--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -1,12 +1,12 @@
-name: Ubuntu 20.04 / Qt 6.5.0
+name: Ubuntu 22.04 / Qt 6.5.0
 on:
   workflow_run:
     workflows: ["Release setup"]
     types: [completed]
 
 jobs:
-  buildUbuntuXenial:
-    runs-on: ubuntu-20.04
+  buildUbuntu:
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest, ubuntu-20.04]
+        os: [ubuntu-latest, macos-latest, windows-latest, ubuntu-22.04]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/wasm-release.yml
+++ b/.github/workflows/wasm-release.yml
@@ -5,8 +5,8 @@ on:
       - '**'
 
 jobs:
-  buildUbuntuXenial:
-    runs-on: ubuntu-20.04
+  buildUbuntu:
+    runs-on: ubuntu-22.04
     env:
       CC: emcc
       CXX: em++

--- a/docker/ripes.dockerfile
+++ b/docker/ripes.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/docs/new_processor_models.md
+++ b/docs/new_processor_models.md
@@ -67,7 +67,7 @@ The benefits are clear - by inserting a processor model into the Ripes environme
 
 Preliminary work has been done to integrate the [PicoRV32](https://github.com/cliffordwolf/picorv32) core into Ripes. The work is available on [this](https://github.com/mortbopet/Ripes/tree/picorv32/src/processors/PicoRV32) branch. While a simple core, it demonstrates the process of using a Verilator-generated processor model in Ripes. Hopefully, this work can be a foundation/guide to include more complex multi-stage processors.
 
-The following steps were taken to integrate the model into Ripes. This has **only** been tested on Linux (Ubunbtu 20.04).
+The following steps were taken to integrate the model into Ripes. This has **only** been tested on Linux (Ubunbtu 22.04).
 
 - First, make sure that you have Verilator installed.
 - The environment variable `VERILATOR_ROOT` must be set to base directory of verilator ([see this](https://veripool.org/guide/latest/install.html#installation)).


### PR DESCRIPTION
Github has deprecated 20.04 for github-hosted runners. 22.04 is now the new minimum supported version.