### PR TITLE
Fix: file write syscall to correctly output raw binary data

### DIFF
--- a/src/syscall/file.h
+++ b/src/syscall/file.h
@@ -129,7 +129,7 @@ public:
       return;
     }
     int index = 0;
-    QString myBuffer;
+    QByteArray myBuffer;
 
     do {
       myBuffer.append(static_cast<char>(

--- a/src/syscall/systemio.h
+++ b/src/syscall/systemio.h
@@ -412,7 +412,7 @@ public:
    * @return number of bytes written, or -1 on error
    */
 
-  static int writeToFile(int fd, const QString &myBuffer, int lengthRequested) {
+  static int writeToFile(int fd, const QByteArray &myBuffer, int lengthRequested) {
     SystemIO::get(); // Ensure that SystemIO is constructed
     if (fd == STDOUT || fd == STDERR) {
       emit get().doPrint(myBuffer);
@@ -430,7 +430,7 @@ public:
     // retrieve FileOutputStream from storage
     auto &outputStream = FileIOData::getStreamInUse(fd);
 
-    outputStream << myBuffer;
+    outputStream.device()->write(myBuffer);
     outputStream.flush();
     return lengthRequested;
 


### PR DESCRIPTION
Previously, the RISC-V write syscall in Ripes interpreted memory content as a QString, which implicitly assumes UTF-8 encoding. This caused incorrect output when writing binary data, particularly when bytes had values above 127 (0x7F).

In UTF-8, codepoints above 127 are encoded using multiple bytes. For example, the byte 0xA0 is encoded in UTF-8 as the two-byte sequence 0xC2 0xA0. As a result, using QString for raw memory meant that writing a single byte from memory could result in multiple unintended bytes being emitted to the output stream.

This PR replaces the use of QString with QByteArray, ensuring that the written data is treated as a raw byte buffer rather than UTF-8 encoded text. This change preserves the exact memory contents intended by the simulated program, enabling correct output through the write syscall.