### PR TITLE
Fix random replacement policy and ensure minimum 1-way cache

### DIFF
--- a/src/cachesim/cachesim.cpp
+++ b/src/cachesim/cachesim.cpp
@@ -548,7 +548,7 @@ void CacheSim::setLines(unsigned lines) {
 }
 
 void CacheSim::setWays(unsigned ways) {
-  m_ways = ways;
+  m_ways = std::max(1u, ways);
   updateConfiguration();
 }
 
@@ -569,7 +569,7 @@ void CacheSim::setReplacementPolicy(ReplPolicy policy) {
 
 void CacheSim::setPreset(const CachePreset &preset) {
   m_blocks = preset.blocks;
-  m_ways = preset.ways;
+  m_ways = std::max(1, preset.ways);
   m_lines = preset.lines;
   m_wrPolicy = preset.wrPolicy;
   m_wrAllocPolicy = preset.wrAllocPolicy;

--- a/src/ripessettings.cpp
+++ b/src/ripessettings.cpp
@@ -44,7 +44,7 @@ const std::map<QString, QVariant> s_defaultSettings = {
     {RIPES_SETTING_CACHE_MAXTRACES, 10000},
     {RIPES_SETTING_CACHE_PRESETS,
      QVariant::fromValue<QList<CachePreset>>(
-         {CachePreset{"32-entry 4-word direct-mapped", 2, 5, 0,
+         {CachePreset{"32-entry 4-word direct-mapped", 2, 5, 1,
                       WritePolicy::WriteBack, WriteAllocPolicy::WriteAllocate,
                       ReplPolicy::LRU},
           CachePreset{"32-entry 4-word fully associative", 2, 0, 5,


### PR DESCRIPTION
This PR fixes the *Random* replacement policy and ensures cache presets cannot initialize with `0` ways. Prevents unnecessary evictions and crashes.

**What was happening before**
1. The *Random* replacement policy selected random lines even when free lines were still available, leading to unnecessary cache misses.
2. Some cache presets could initialize with `ways = 0`, causing crashes or undefined eviction behavior.
    - This could be reproduced by selecting the preset **"32-entry 4-word direct-mapped"** or by manually setting `ways = 0` in *L1 Instruction Cache* (confirmed in the latest official release).

**What's changed**
- Updated `locateEvictionWay()` so that free (invalid) lines are now filled before any eviction happens.
- Updated `setWays()` and `setPreset()` to ensure a minimum of `1` way is always used.
  
**Testing**
- Verified that cache lines fill sequentially before eviction occurs in random policy.
- Confirmed no crashes occur with invalid presets or `0`-way caches.
- Tested with multiple configurations (direct-mapped, 2-way, fully associative).
- Confirmed that the LRU policy remains unaffected.

### Visual demonstration

Using this assembly snippet:
```asm
.text
loop:
    addi a0, a0, 1    
    addi a1, a1, 2    
    addi a2, a2, 3    
    addi a3, a3, 4    

    mul a4, a0, a2    
    mul a1, a1, a1   
    mul a2, a2, a2   
    mul a3, a3, a3
    
    addi t0, t0, 5 
    addi t1, t1, 6 
    addi t2, t2, 7 
    addi t3, t3, 8 

    addi s0, s0, 9 
    addi s1, s1, 10 
    addi s2, s2, 11
    addi s3, s3, 12 

    
    li a6, 3
    bne a0, a6, loop
```
Using **fully associative** (1 line, 5 ways, 4 words/line) and a **single-cycle processor**.

**Before**

https://github.com/user-attachments/assets/6e67ea2e-7435-4297-94ce-281a75841a23

**After**

https://github.com/user-attachments/assets/5080249f-bf54-445a-8efe-caf4d7f89508

**Note:** In this test case, the final cache misses decreased from 8 → 5 due to the fix (this number may vary).