### PR TITLE
Fix incorrect MULH/MULHU/MULHSU calculation logic in 64-bit ALU

### DIFF
--- a/src/processors/RISC-V/rv_alu.h
+++ b/src/processors/RISC-V/rv_alu.h
@@ -32,19 +32,40 @@ public:
       case ALUOp::MUL:
         return VT_U(op1.sValue() * op2.sValue());
       case ALUOp::MULH: {
-        const auto result = static_cast<int64_t>(op1.sValue()) *
-                            static_cast<int64_t>(op2.sValue());
-        return VT_U(result >> 32);
+        if constexpr (XLEN == 32) {
+          const auto result = static_cast<int64_t>(op1.sValue()) *
+                              static_cast<int64_t>(op2.sValue());
+          return VT_U(result >> 32);
+        } else {
+          const __int128_t result = static_cast<__int128_t>(op1.sValue()) *
+                                    static_cast<__int128_t>(op2.sValue());
+          return VT_U(result >> 64);
+        }
       }
       case ALUOp::MULHU: {
-        const auto result = static_cast<uint64_t>(op1.uValue()) *
-                            static_cast<uint64_t>(op2.uValue());
-        return VT_U(result >> 32);
+        if constexpr (XLEN == 32) {
+          const uint64_t result = static_cast<uint64_t>(op1.uValue()) *
+                                  static_cast<uint64_t>(op2.uValue());
+          return VT_U(result >> 32);
+        } else {
+          const unsigned __int128 result =
+              static_cast<unsigned __int128>(op1.uValue()) *
+              static_cast<unsigned __int128>(op2.uValue());
+          return VT_U(result >> 64);
+        }
       }
       case ALUOp::MULHSU: {
-        const int64_t result = static_cast<int64_t>(op1.sValue()) *
-                               static_cast<uint64_t>(op2.uValue());
-        return VT_U(result >> 32);
+        if constexpr (XLEN == 32) {
+          const int64_t result = static_cast<int64_t>(op1.sValue()) *
+                                 static_cast<uint64_t>(op2.uValue());
+          return VT_U(result >> 32);
+        } else {
+          const __int128_t result =
+              static_cast<__int128_t>(op1.sValue()) *
+              static_cast<__int128_t>(
+                  static_cast<unsigned __int128>(op2.uValue()));
+          return VT_U(result >> 64);
+        }
       }
 
       case ALUOp::DIVW:

--- a/src/processors/RISC-V/rv_alu.h
+++ b/src/processors/RISC-V/rv_alu.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#ifdef _MSC_VER
+#include <intrin.h>
+#endif
+
 #include "limits.h"
 #include <assert.h>
 #include <math.h>
@@ -37,9 +41,17 @@ public:
                               static_cast<int64_t>(op2.sValue());
           return VT_U(result >> 32);
         } else {
+#ifdef _MSC_VER
+          // Windows (MSVC) implementation
+          int64_t high;
+          _mul128(op1.sValue(), op2.sValue(), &high);
+          return VT_U(high);
+#else
+          // Linux/macOS (GCC/Clang) implementation
           const __int128_t result = static_cast<__int128_t>(op1.sValue()) *
                                     static_cast<__int128_t>(op2.sValue());
           return VT_U(result >> 64);
+#endif
         }
       }
       case ALUOp::MULHU: {
@@ -48,10 +60,18 @@ public:
                                   static_cast<uint64_t>(op2.uValue());
           return VT_U(result >> 32);
         } else {
+#ifdef _MSC_VER
+          // Windows (MSVC) implementation
+          unsigned __int64 high;
+          _umul128(op1.uValue(), op2.uValue(), &high);
+          return VT_U(high);
+#else
+          // Linux/macOS (GCC/Clang) implementation
           const unsigned __int128 result =
               static_cast<unsigned __int128>(op1.uValue()) *
               static_cast<unsigned __int128>(op2.uValue());
           return VT_U(result >> 64);
+#endif
         }
       }
       case ALUOp::MULHSU: {
@@ -60,11 +80,22 @@ public:
                                  static_cast<uint64_t>(op2.uValue());
           return VT_U(result >> 32);
         } else {
+#ifdef _MSC_VER
+          // Windows (MSVC) implementation for Mixed Signed * Unsigned
+          unsigned __int64 high;
+          _umul128(static_cast<uint64_t>(op1.sValue()), op2.uValue(), &high);
+          if (op1.sValue() < 0) {
+            high -= op2.uValue();
+          }
+          return VT_U(high);
+#else
+          // Linux/macOS (GCC/Clang) implementation
           const __int128_t result =
               static_cast<__int128_t>(op1.sValue()) *
               static_cast<__int128_t>(
                   static_cast<unsigned __int128>(op2.uValue()));
           return VT_U(result >> 64);
+#endif
         }
       }
 

--- a/test/riscv-tests-64/mulh_test.S
+++ b/test/riscv-tests-64/mulh_test.S
@@ -1,0 +1,68 @@
+.text
+.globl _start
+_start: nop
+
+  #-------------------------------------------------------------
+  # MULH / MULHU / MULHSU Tests
+  #-------------------------------------------------------------
+
+  # x8 = 0x00000058000001fe
+  # x9 = 0x000000b800000000
+  # Expected Result (High 64-bit) = 0x3f40
+
+setup_regs:
+  li x8, 11
+  slli x8, x8, 35
+  ori x8, x8, 254
+  
+  li x9, 23
+  slli x9, x9, 35
+  ori x8, x8, 424 
+  
+  li x7, 0x3f40   # Expected result in x7
+
+  #-------------------------------------------------------------
+  # Test 2: mulh (Signed High)
+  #-------------------------------------------------------------
+test_2:
+  li gp, 2        # Test case number
+  mulh x14, x8, x9
+  bne x14, x7, fail
+
+  #-------------------------------------------------------------
+  # Test 3: mulhu (Unsigned High)
+  #-------------------------------------------------------------
+test_3:
+  li gp, 3
+  mulhu x14, x8, x9
+  bne x14, x7, fail
+
+  #-------------------------------------------------------------
+  # Test 4: mulhsu (Signed x Unsigned High)
+  #-------------------------------------------------------------
+test_4:
+  li gp, 4
+  mulhsu x14, x8, x9
+  bne x14, x7, fail
+
+
+  bne x0, gp, pass
+
+fail: 
+  li a0, 0    # Return code 0 for FAILURE
+  li a7, 93   # Syscall exit
+  ecall
+
+pass: 
+  li a0, 42   # Return code 42 for SUCCESS
+  li a7, 93   # Syscall exit
+  ecall
+
+  .data
+  .align 4
+  .global begin_signature
+begin_signature:
+
+  .align 4
+  .global end_signature
+end_signature:


### PR DESCRIPTION
This PR fixes a bug in the ALU implementation where `mulh`, `mulhu`, and `mulhsu` instructions were calculating incorrect results when running on a 64-bit processor model.

The original implementation shared the same logic for both 32-bit and 64-bit architectures (take `mulh` for example):

```cpp
    const auto result = static_cast<int64_t>(op1.sValue()) *
                        static_cast<int64_t>(op2.sValue());
    return VT_U(result >> 32);
```
For RV64, this logic is flawed because it truncates the 128-bit product (64-bit * 64-bit) into a 64-bit container and it shift by only 32 bits, which means returning bits [63:32] of the result instead of [127:64].

The commit updated `rv_alu.h` to check for `XLEN`. If `XLEN=64`, the ALU now uses `__int128_t` for calculation and shifts the result by 64 bits to correctly retrieve the high part of the product.

## Verification
I verified the fix using a custom assembly program provided in [issue#344](https://github.com/mortbopet/Ripes/issues/344), which performs multiplication that exceeds 64 bits.

<details>
<summary>Assembly Codes for Testing (from Issue #344)</summary>

```
li x8, 11
slli x8, x8, 35
ori x8, x8, 254

li x9, 23
slli x9, x9, 35
ori x8, x8, 424

mul x10, x8, x9
mulh x11, x8, x9
mulhu x12, x8, x9
mulhsu x13, x8, x9
```

</details>

Operand 1 (x8): `0x00000058000001fe`
Operand 2 (x9): `0x000000b800000000`
Expected High Part (x11): `0x0000000000003f40`

Before Fix:
Result in x11: `0x0000000000016E90` (Matches bits [63:32] of the product)

<img width="363" height="179" alt="before" src="https://github.com/user-attachments/assets/8d62a56f-ab0e-445f-b28c-90b12abd9d83" />

After Fix:
Result in x11: `0x0000000000003F40` (Matches the expected 128-bit high part)

<img width="363" height="179" alt="after" src="https://github.com/user-attachments/assets/58e2a542-6084-49ab-bbf7-a2dc2b3bf8f2" />

