### PR TITLE
Use cache to speed up actions

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -11,6 +11,20 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       -
+        name: Cache Docker mounts
+        uses: actions/cache@v3
+        with:
+          path: /tmp/docker-ccache
+          key: ccache-docker-${{ github.sha }}
+          restore-keys: |
+            ccache-docker-
+      -
+        name: Inject cache into Docker
+        uses: reproducible-containers/buildkit-cache-dance@v3.1.0
+        with:
+          cache-source: /tmp/docker-ccache
+          cache-target: /ccache
+      -
         name: Build and push
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -8,11 +8,6 @@ jobs:
       -
         uses: actions/checkout@v2
       -
-        run: apt update # for ccache
-      -
-        name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2
-      -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       -

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -8,6 +8,11 @@ jobs:
       -
         uses: actions/checkout@v2
       -
+        run: apt update # for ccache
+      -
+        name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+      -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       -

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -16,3 +16,5 @@ jobs:
         with:
           file: "./docker/ripes.dockerfile"
           context: "./docker/"
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -16,6 +16,20 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       -
+        name: Cache Docker mounts
+        uses: actions/cache@v3
+        with:
+          path: /tmp/docker-ccache
+          key: ccache-docker-${{ github.sha }}
+          restore-keys: |
+            ccache-docker-
+      -
+        name: Inject cache into Docker
+        uses: reproducible-containers/buildkit-cache-dance@v3.1.0
+        with:
+          cache-source: /tmp/docker-ccache
+          cache-target: /ccache
+      -
         name: Login to DockerHub
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -13,11 +13,6 @@ jobs:
       -
         uses: actions/checkout@v2
       -
-        run: apt update # for ccache
-      -
-        name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2
-      -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       -

--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -29,3 +29,5 @@ jobs:
           context: "./docker/"
           push: true
           tags: mortbopet/ripes:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -13,6 +13,11 @@ jobs:
       -
         uses: actions/checkout@v2
       -
+        run: apt update # for ccache
+      -
+        name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+      -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       -

--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -50,11 +50,16 @@ jobs:
         submodules: recursive
         fetch-depth: 0
 
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ${{ github.job }}-${{ matrix.build-type }}
+
     - name: build Ripes
       run: |
         echo "--------------------------------------------------------------"
         echo "building desktop"
-        cmake -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} . -GNinja
+        cmake -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache . -GNinja
         ninja
 
     - name: package artifacts

--- a/.github/workflows/mac-release.yml
+++ b/.github/workflows/mac-release.yml
@@ -19,6 +19,11 @@ jobs:
         submodules: 'recursive'
         fetch-depth: 0
 
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ${{ github.job }}-${{ matrix.build-type }}
+
     - name: setup Homebrew
       run: brew install autoconf automake libtool xz  pkg-config libgit2 libjpg libpng libmtp svg2png
 
@@ -40,7 +45,7 @@ jobs:
         export PATH=$QT_ROOT/bin:$PATH
         export CMAKE_PREFIX_PATH=$QT_ROOT/lib/cmake
         DIR=$(pwd)
-        cmake -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" .
+        cmake -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache .
         make
 
     - name: package artifacts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     - name: ccache
       uses: hendrikmuhs/ccache-action@v1.2
       with:
-        key: ${{ matrix.os }}-ccache
+        key: ${{ matrix.os }}-testcache
         variant: ${{ contains(matrix.os, 'windows') && 'sccache' || 'ccache' }}
 
     # Container preparation

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,9 @@ jobs:
       with:
         submodules: recursive
 
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+
     # Container preparation
       # Ubuntu
     - if: contains( matrix.os, 'ubuntu')
@@ -74,14 +77,14 @@ jobs:
     - if: "!contains(matrix.os, 'windows')"
       name: build Ripes
       run: |
-        cmake -GNinja -DRIPES_BUILD_TESTS=ON -DVSRTL_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Release .
+        cmake -GNinja -DRIPES_BUILD_TESTS=ON -DVSRTL_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache .
         ninja
 
     - if: contains(matrix.os, 'windows')
       name: build Ripes (Windows)
       shell: bash
       run: |
-        cmake -GNinja -DRIPES_BUILD_TESTS=ON -DVSRTL_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl
+        cmake -GNinja -DRIPES_BUILD_TESTS=ON -DVSRTL_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         cmake --build .
 
     # Go test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,9 @@ jobs:
 
     - name: ccache
       uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ${{ matrix.os }}-ccache
+        variant: ${{ contains(matrix.os, 'windows') && 'sccache' || 'ccache' }}
 
     # Container preparation
       # Ubuntu
@@ -84,7 +87,7 @@ jobs:
       name: build Ripes (Windows)
       shell: bash
       run: |
-        cmake -GNinja -DRIPES_BUILD_TESTS=ON -DVSRTL_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+        cmake -GNinja -DRIPES_BUILD_TESTS=ON -DVSRTL_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
         cmake --build .
 
     # Go test

--- a/.github/workflows/wasm-release.yml
+++ b/.github/workflows/wasm-release.yml
@@ -41,6 +41,11 @@ jobs:
         submodules: recursive
         fetch-depth: 0
 
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ${{ github.job }}-wasm-${{ matrix.build-type }}
+
     - name: Install Qt (Host)
       uses: jurplel/install-qt-action@v3
       with:
@@ -88,6 +93,8 @@ jobs:
           -DCMAKE_TOOLCHAIN_FILE=$(pwd)/../Qt/6.6.0/wasm_multithread/lib/cmake/Qt6/qt.toolchain.cmake \
           -DCMAKE_PREFIX_PATH=$(pwd)/../Qt/6.6.0/wasm_multithread/ \
           -DEMSCRIPTEN_FORCE_COMPILERS=ON \
+          -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
           .
         make -j $(nproc)
 

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -34,10 +34,16 @@ jobs:
         submodules: recursive
         fetch-depth: 0
 
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ${{ github.job }}-${{ matrix.build-type }}
+        variant: sccache
+
     - name: build Ripes
       shell: bash
       run: |
-        cmake -GNinja -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl
+        cmake -GNinja -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
         cmake --build .
 
     - name: package artifacts

--- a/docker/ripes.dockerfile
+++ b/docker/ripes.dockerfile
@@ -5,6 +5,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -q \
     && apt-get install -qy --no-install-recommends \
     build-essential \
+    ccache \
     cmake \
     gcc-riscv64-unknown-elf \
     git \
@@ -33,8 +34,11 @@ ARG GIT_SSL_NO_VERIFY=true
 ENV LC_ALL=C.UTF-8 SHELL=/bin/bash
 ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/6.5.0/gcc_64/lib"
 
+ENV CCACHE_DIR=/ccache
+
 ARG BRANCH=master
-RUN git clone --recursive --branch ${BRANCH} https://github.com/mortbopet/Ripes.git /tmp/ripes \
+RUN --mount=type=cache,target=/ccache \
+    git clone --recursive --branch ${BRANCH} https://github.com/mortbopet/Ripes.git /tmp/ripes \
     && cmake -S /tmp/ripes/ \
         -B /tmp/ripes/build \
         -Wno-dev            \


### PR DESCRIPTION
Adds ccache and sscache (for Windows builds) to speed up c++ compilation process. Also, uses github actions own cache mechanism to cache docker layers (alongside ccache mechanism).