### PR TITLE
fix the -Wdeprecated warnings intoduced by the multicycle processors

### DIFF
--- a/src/processors/RISC-V/rv5mc/rv5mc_1m.h
+++ b/src/processors/RISC-V/rv5mc/rv5mc_1m.h
@@ -34,7 +34,7 @@ public:
     // Decode
     this->memory->data_out >> this->ir_widthadjust->in;
     this->ir_widthadjust->out >> this->decode->instr;
-    this->decode->instr << [=] { return this->memory->data_out.uValue(); };
+    this->decode->instr << [this] { return this->memory->data_out.uValue(); };
   }
 
   MemoryAccess dataMemAccess() const override {

--- a/src/processors/RISC-V/rv5mc/rv5mc_alu.h
+++ b/src/processors/RISC-V/rv5mc/rv5mc_alu.h
@@ -25,7 +25,7 @@ public:
 
   RVMCALU(const std::string &name, SimComponent *parent)
       : Component(name, parent) {
-    res << [=] {
+    res << [this] {
       switch (ctrl.eValue<ALUOp>()) {
       case ALUOp::ADD:
         return op1.uValue() + op2.uValue();
@@ -184,15 +184,15 @@ public:
         throw std::runtime_error("Invalid ALU opcode");
       }
     };
-    zero << [=] {
+    zero << [this] {
       if (res.uValue() == 0)
         return 1;
       return 0;
     }; // returns 1 if the result of the ALU is 0
-    sign << [=] {
+    sign << [this] {
       return VT_U(res.sValue() < 0 ? 1 : 0);
     }; // returns 1 if the ALU result is negative or 0 if it is not
-    carry << [=] {
+    carry << [this] {
       switch (ctrl.eValue<ALUOp>()) {
       case ALUOp::ADD:
         if (XLEN == 32)

--- a/src/processors/RISC-V/rv5mc/rv5mc_control.h
+++ b/src/processors/RISC-V/rv5mc/rv5mc_control.h
@@ -330,31 +330,31 @@ public:
 
     setInitialState();
 
-    ir_write << [=] { return getCurrentStateInfo().outs.ir_write; };
-    pc_write << [=] { return getCurrentStateInfo().outs.pc_write; };
-    branch << [=] { return getCurrentStateInfo().outs.branch; };
-    pc_src << [=] { return getCurrentStateInfo().outs.pc_src; };
-    reg_write << [=] { return getCurrentStateInfo().outs.reg_write; };
-    reg_src << [=] { return getCurrentStateInfo().outs.reg_src; };
-    alu_op1_src << [=] { return getCurrentStateInfo().outs.alu_op1_src; };
-    alu_op2_src << [=] { return getCurrentStateInfo().outs.alu_op2_src; };
-    alu_ctrl << [=] {
+    ir_write << [this] { return getCurrentStateInfo().outs.ir_write; };
+    pc_write << [this] { return getCurrentStateInfo().outs.pc_write; };
+    branch << [this] { return getCurrentStateInfo().outs.branch; };
+    pc_src << [this] { return getCurrentStateInfo().outs.pc_src; };
+    reg_write << [this] { return getCurrentStateInfo().outs.reg_write; };
+    reg_src << [this] { return getCurrentStateInfo().outs.reg_src; };
+    alu_op1_src << [this] { return getCurrentStateInfo().outs.alu_op1_src; };
+    alu_op2_src << [this] { return getCurrentStateInfo().outs.alu_op2_src; };
+    alu_ctrl << [this] {
       auto c = getCurrentStateInfo().outs.alu_control;
       return c == ALUControl::INSTRUCTION_DEPENDENT ? do_alu_ctrl(getCurrentOpcode())
       : c == ALUControl::ADD ? ALUOp::ADD
       : (assert(c == ALUControl::SUB), ALUOp::SUB);
     };
-    mem_write << [=] { return getCurrentStateInfo().outs.mem_write; };
-    mem_addr_src << [=] { return getCurrentStateInfo().outs.mem_addr_src; };
+    mem_write << [this] { return getCurrentStateInfo().outs.mem_write; };
+    mem_addr_src << [this] { return getCurrentStateInfo().outs.mem_addr_src; };
 
-    mem_ctrl << [=] { return (mem_addr_src.eValue<MemAddrSrc>() == MemAddrSrc::PC) ? MemOp::LW : do_mem_ctrl(getCurrentOpcode());};
-    comp_ctrl << [=] { return do_comp_ctrl(getCurrentOpcode()); };
+    mem_ctrl << [this] { return (mem_addr_src.eValue<MemAddrSrc>() == MemAddrSrc::PC) ? MemOp::LW : do_mem_ctrl(getCurrentOpcode());};
+    comp_ctrl << [this] { return do_comp_ctrl(getCurrentOpcode()); };
 
     // ecall signal is inverted
-    ecall << [=] { return !getCurrentStateInfo().outs.ecall; };
+    ecall << [this] { return !getCurrentStateInfo().outs.ecall; };
 
-    next_state << [=] { return getNextState(); };
-    current_state << [=] { return getCurrentState(); };
+    next_state << [this] { return getNextState(); };
+    current_state << [this] { return getCurrentState(); };
 
     next_state >> state_reg->in;
   }

--- a/src/processors/RISC-V/rv5mc/rv5mc_zextortruncate.h
+++ b/src/processors/RISC-V/rv5mc/rv5mc_zextortruncate.h
@@ -10,7 +10,7 @@ class ZExtOrTruncate : public Component {
 public:
   ZExtOrTruncate(std::string name, SimComponent *parent)
       : Component(name, parent) {
-    out << [=] { return in.uValue(); };
+    out << [this] { return in.uValue(); };
   }
 
   INPUTPORT(in, INLEN);


### PR DESCRIPTION
fixed all -Wdeprecated warnings:
```
warning: implicit capture of ‘this’ via ‘[=]’ is deprecated in C++20 [-Wdeprecated]
```

by replacing `[=]` (which implicitely captures `this`) with `[this]` to be conform with C++20