### PR TITLE
Fix #460

### DIFF
--- a/.github/workflows/scripts/run_tests.sh
+++ b/.github/workflows/scripts/run_tests.sh
@@ -3,7 +3,7 @@
 # Fail on failing QTest execution
 set -e
 
-find . -executable -type f -name "tst_*" | while read line; do
+find . -type f -name "tst_*" -exec test -x {} \; -print | while read line; do
     echo "Running unit test: "
     echo "${line}"
     ($line)


### PR DESCRIPTION
Fixes #460. Due to the bug fixed in #459, the clang format action fails on this pull request. It could be ignored or merged after #459.